### PR TITLE
Change tag/attribute keys to owned Strings to allow dynamic creation

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -189,12 +189,13 @@ pub fn add_child<MSG>(stack: &mut Stack<MSG>, child: VNode<MSG>) {
 #[doc(hidden)]
 pub fn child_to_parent<MSG>(stack: &mut Stack<MSG>, endtag: Option<&'static str>) {
     if let Some(node) = stack.pop() {
-        let starttag = node.tag();
         if let Some(endtag) = endtag {
+            let starttag = node.tag();
             if starttag != endtag {
                 panic!("wrong closing tag: <{}> -> </{}>", starttag, endtag);
             }
         }
+
         if !stack.is_empty() {
             stack.last_mut().unwrap().add_child(VNode::from(node));
         } else {

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -25,7 +25,7 @@ impl<MSG> fmt::Debug for Listener<MSG> {
 
 pub type Messages<MSG> = Rc<RefCell<Vec<MSG>>>;
 type Listeners<MSG> = Vec<Box<Listener<MSG>>>;
-type Attributes = HashMap<&'static str, String>;
+type Attributes = HashMap<String, String>;
 type Classes = HashSet<String>;
 
 enum Patch<ID, T> {

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -48,14 +48,14 @@ impl<MSG> VNode<MSG> {
                         *reference = Some(element);
                     }
                     Some(VNode::VText { reference: Some(wrong), .. }) => {
-                        let element = document().create_element(left.tag);
+                        let element = document().create_element(&left.tag);
                         parent.replace_child(&element, &wrong);
                         *reference = Some(element);
                     }
                     Some(VNode::VTag { reference: None, .. }) |
                     Some(VNode::VText { reference: None, .. }) |
                     None => {
-                        let element = document().create_element(left.tag);
+                        let element = document().create_element(&left.tag);
                         parent.append_child(&element);
                         *reference = Some(element);
                     }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -1,4 +1,5 @@
 use std::fmt;
+use std::borrow::Cow;
 use std::collections::HashSet;
 use stdweb::web::{IElement, Element, EventListenerHandle};
 use stdweb::web::html_element::InputElement;
@@ -6,7 +7,7 @@ use stdweb::unstable::TryFrom;
 use virtual_dom::{Messages, Listener, Listeners, Classes, Attributes, Patch, VNode};
 
 pub struct VTag<MSG> {
-    pub tag: &'static str,
+    pub tag: Cow<'static, str>,
     pub listeners: Listeners<MSG>,
     pub captured: Vec<EventListenerHandle>,
     pub attributes: Attributes,
@@ -18,9 +19,9 @@ pub struct VTag<MSG> {
 }
 
 impl<MSG> VTag<MSG> {
-    pub fn new(tag: &'static str) -> Self {
+    pub fn new<S: Into<Cow<'static, str>>>(tag: S) -> Self {
         VTag {
-            tag: tag,
+            tag: tag.into(),
             classes: Classes::new(),
             attributes: Attributes::new(),
             listeners: Vec::new(),
@@ -34,15 +35,15 @@ impl<MSG> VTag<MSG> {
         }
     }
 
-    pub fn tag(&self) -> &'static str {
-        self.tag
+    pub fn tag(&self) -> &str {
+        &self.tag
     }
 
     pub fn add_child(&mut self, child: VNode<MSG>) {
         self.childs.push(child);
     }
 
-    pub fn add_classes(&mut self, class: &'static str) {
+    pub fn add_classes(&mut self, class: &str) {
         let class = class.trim();
         if !class.is_empty() {
             self.classes.insert(class.into());
@@ -61,8 +62,8 @@ impl<MSG> VTag<MSG> {
         self.checked = value;
     }
 
-    pub fn add_attribute<T: ToString>(&mut self, name: &'static str, value: T) {
-        self.attributes.insert(name, value.to_string());
+    pub fn add_attribute<T: ToString>(&mut self, name: &str, value: T) {
+        self.attributes.insert(name.to_owned(), value.to_string());
     }
 
     pub fn add_listener(&mut self, listener: Box<Listener<MSG>>) {


### PR DESCRIPTION
Having the tag / attribute keys as static strings is great for when you are composing a node tree from macros or a pre-defined tree structure in a function, but sometimes we want to create tag names programatically. For example, I ran into this because I am trying to make a markdown -> yew::html::Html parser, and I need to interpolate the header level like `VTag::new(format!("<h{}>", level))`, which is not currently possible because the tag name is a static string.

This PR just changes it to an owned string on the VTag, and does the same for the attributes HashMap.