### PR TITLE
Fixed to allow multiple classes on an element

### DIFF
--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -42,9 +42,9 @@ impl<MSG> VTag<MSG> {
         self.childs.push(child);
     }
 
-    pub fn add_classes(&mut self, class: &'static str) {
-        let class = class.trim();
-        if !class.is_empty() {
+    pub fn add_classes(&mut self, classes: &'static str) {
+        let classes = classes.trim();
+        for class in classes.split_whitespace() {
             self.classes.insert(class.into());
         }
     }


### PR DESCRIPTION
When more than one class was applied to an element it errored out

for example
```
<div class="button button-primary" />
```

This fixes to account for that.