### PR TITLE
Drop Timer and Interval services callbacks on cancel

### DIFF
--- a/src/services/interval.rs
+++ b/src/services/interval.rs
@@ -3,9 +3,7 @@ use stdweb::Value;
 use html::Context;
 use super::{Task, to_ms};
 
-pub struct IntervalHandle {
-    interval_id: Option<Value>,
-}
+pub struct IntervalHandle(Option<Value>);
 
 pub trait IntervalService<MSG> {
     fn interval<F>(&mut self, duration: Duration, converter: F) -> IntervalHandle
@@ -24,27 +22,28 @@ impl<MSG: 'static> IntervalService<MSG> for Context<MSG> {
             tx.send(msg);
         };
         let ms = to_ms(duration);
-        let id = js! {
+        let handle = js! {
             var callback = @{callback};
             let action = function() {
                 callback();
             };
             let delay = @{ms};
-            return setInterval(action, delay);
+            return {
+                interval_id: setInterval(action, delay),
+                callback,
+            };
         };
-        IntervalHandle {
-            interval_id: Some(id),
-        }
+        IntervalHandle(Some(handle))
     }
 }
 
 impl Task for IntervalHandle {
     fn cancel(&mut self) {
-        let interval_id = self.interval_id.take().expect("tried to cancel interval twice");
+        let handle = self.0.take().expect("tried to cancel interval twice");
         js! {
-            // TODO Drop the callback to prevent memory leak
-            var id = @{interval_id};
-            clearInterval(id);
+            var handle = @{handle};
+            clearInterval(handle.interval_id);
+            handle.callback.drop();
         }
     }
 }


### PR DESCRIPTION
This fixes #12

As we have to store both id and callback in our handles, I refactored them to unit structs. Of course, we could destructure the returned object into two separate fields, so it could be more explicit for users what exactly we store there. But I ~~felt lazy~~ I'm not sure that someone is going to use them outside.
