### PR TITLE
Make html macro return an expression

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -107,10 +107,10 @@ macro_rules! html_impl {
 // This entrypoint and implementation had separated to prevent infinite recursion.
 #[macro_export]
 macro_rules! html {
-    ($($tail:tt)*) => {
+    ($($tail:tt)*) => {{
         let mut stack = Vec::new();
         html_impl! { stack ($($tail)*) }
-    };
+    }};
 }
 
 type Stack<MSG> = Vec<VTag<MSG>>;


### PR DESCRIPTION
This makes the following work
```rust
let x = html!(<div></div>);
```

when previously it would give the error

```
error: expected expression, found statement (`let`)
 --> src/main.rs:5:36
  |
5 |    let test: yew::html::Html<()> = html!(<div></div>);
  |                                    ^^^^^^^^^^^^^^^^^^
  |
  = note: variable declaration using `let` is a statement
  = note: this error originates in a macro outside of the current crate (in Nightly builds, run with -Z external-macro-backtrace for more info)

error: Could not compile `yewtest`.
```
