### PR TITLE
Example fixes: todomvc edit mode styles, crm clear inputs

### DIFF
--- a/examples/crm/src/main.rs
+++ b/examples/crm/src/main.rs
@@ -39,6 +39,8 @@ fn update(context: &mut Context<Msg>, model: &mut Model, msg: Msg) {
                 last_name: model.last_name_value.clone(),
             };
             model.clients.push(client);
+            model.first_name_value = "".to_string();
+            model.last_name_value = "".to_string();
         }
         Msg::UpdateFirstName(val) => {
             println!("Input: {}", val);

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -180,30 +180,30 @@ fn view_input(model: &Model) -> Html<Msg> {
 
 fn view_entry((idx, entry): (usize, &Entry)) -> Html<Msg> {
     html! {
-        <li>
+        <li class={ if entry.editing == true { "editing" } else { "" }},>
             <div class="view",>
                 <input class="toggle", type="checkbox", checked=entry.completed, onclick=move|_| Msg::Toggle(idx), />
-                { view_entry_label((idx, &entry)) }
+                <label ondoubleclick=move|_| Msg::ToggleEdit(idx),>{ &entry.description }</label>
                 <button class="destroy", onclick=move |_| Msg::Remove(idx),></button>
             </div>
+            { view_entry_edit_input((idx, &entry)) }
         </li>
     }
 }
 
-fn view_entry_label((idx, entry): (usize, &Entry)) -> Html<Msg> {
+fn view_entry_edit_input((idx, entry): (usize, &Entry)) -> Html<Msg> {
     if entry.editing == true {
         html! {
-            <label><input type="text", 
-                          value=&entry.description,
-                          oninput=|e: InputData| Msg::UpdateEdit(e.value),
-                          onkeypress=move |e: KeyData| {
-                            if e.key == "Enter" { Msg::Edit(idx) } else { Msg::Nope }
-                          }, /></label>
+            <input class="edit",
+                   type="text", 
+                   value=&entry.description,
+                   oninput=|e: InputData| Msg::UpdateEdit(e.value),
+                   onkeypress=move |e: KeyData| {
+                      if e.key == "Enter" { Msg::Edit(idx) } else { Msg::Nope }
+                   }, />
         }
     } else {
-        html! {
-            <label ondoubleclick=move|_| Msg::ToggleEdit(idx),>{ &entry.description }</label>
-        }
+        html! { <input type="hidden", /> }
     }
 }
 


### PR DESCRIPTION
Fix Todomvc edit mode styles:

<img width="664" alt="screen shot 2017-12-28 at 11 30 36 am" src="https://user-images.githubusercontent.com/3682072/34421330-7fa9ac00-ebc3-11e7-8bef-6b25570b1675.png">

Clear first and last name inputs when adding a new contact in CRM example.
<img width="315" alt="screen shot 2017-12-27 at 8 53 09 am" src="https://user-images.githubusercontent.com/3682072/34421376-c51d5e8a-ebc3-11e7-8ff3-93426ea16209.png">
