### PR TITLE
Add many console methods

### DIFF
--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -6,7 +6,7 @@ use yew::html::*;
 use yew::services::Task;
 use yew::services::timeout::TimeoutService;
 use yew::services::interval::IntervalService;
-use yew::services::console::{ConsoleService};
+use yew::services::console::ConsoleService;
 
 struct Model {
     job: Option<Box<Task>>,
@@ -46,7 +46,6 @@ fn update(context: &mut Context<Msg>, model: &mut Model, msg: Msg) {
             }
             model.messages.push("Canceled!");
             console.warn("Canceled!");
-            console.trace();
             console.assert(model.job.is_none(), "Job still exists!");
         }
         Msg::Done => {

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -6,7 +6,7 @@ use yew::html::*;
 use yew::services::Task;
 use yew::services::timeout::TimeoutService;
 use yew::services::interval::IntervalService;
-use yew::services::console::{ConsoleService, Level};
+use yew::services::console::{ConsoleService};
 
 struct Model {
     job: Option<Box<Task>>,
@@ -22,32 +22,44 @@ enum Msg {
 }
 
 fn update(context: &mut Context<Msg>, model: &mut Model, msg: Msg) {
+    let console = context.get_console();
     match msg {
         Msg::StartTimeout => {
             let handle = context.timeout(Duration::from_secs(3), || Msg::Done);
             model.job = Some(Box::new(handle));
             model.messages.clear();
+            console.clear();
             model.messages.push("Timer started!!");
+            console.time_named("Timer");
         }
         Msg::StartInterval => {
             let handle = context.interval(Duration::from_secs(1), || Msg::Tick);
             model.job = Some(Box::new(handle));
             model.messages.clear();
+            console.clear();
             model.messages.push("Interval started!");
-            context.console(Level::Log, "Interval started!");
+            console.log("Interval started!");
         }
         Msg::Cancel => {
             if let Some(mut task) = model.job.take() {
                 task.cancel();
             }
             model.messages.push("Canceled!");
+            console.warn("Canceled!");
+            console.trace();
+            console.assert(model.job.is_none(), "Job still exists!");
         }
         Msg::Done => {
             model.messages.push("Done!");
+            console.group();
+            console.info("Done!");
+            console.time_named_end("Timer");
+            console.group_end();
             model.job = None;
         }
         Msg::Tick => {
             model.messages.push("Tick...");
+            console.count_named("Tick");
         }
     }
 }

--- a/src/services/console.rs
+++ b/src/services/console.rs
@@ -1,21 +1,37 @@
 use html::Context;
 
-pub enum Level {
-    Log,
-    Warn,
-    Error,
+pub struct Console;
+
+impl Console {
+    pub fn log(&self, message: &str) { js! { console.log(@{message}); } }
+    pub fn warn(&self, message: &str) { js! { console.warn(@{message}); } }
+    pub fn info(&self, message: &str) { js! { console.info(@{message}); } }
+    pub fn error(&self, message: &str) { js! { console.error(@{message}); } }
+    pub fn debug(&self, message: &str) { js! { console.debug(@{message}); } }
+    pub fn count_named(&self, name: &str) { js! { console.count(@{name}); } }
+    pub fn count(&self, name: &str) { js! { console.count(); } }
+
+    pub fn time_named(&self, name: &str) { js! { console.time(@{name}); } }
+    pub fn time_named_end(&self, name: &str) { js! { console.timeEnd(@{name}); } }
+
+    pub fn time(&self) { js! { console.time(); } }
+    pub fn time_end(&self) { js! { console.timeEnd(); } }
+
+    pub fn clear(&self) { js! { console.clear(); } }
+    pub fn group(&self) { js! { console.group(); } }
+    pub fn group_collapsed(&self) { js! { console.groupCollapsed(); } }
+    pub fn group_end(&self) { js! { console.groupEnd(); } }
+    pub fn trace(&self) { js! { console.trace(); } }
+
+    pub fn assert(&self, condition: bool, message: &str) { js! { console.assert(@{condition}, @{message}); } }
 }
 
 pub trait ConsoleService {
-    fn console(&mut self, level: Level, message: &str);
+    fn get_console(&self) -> Console;
 }
 
 impl<MSG: 'static> ConsoleService for Context<MSG> {
-    fn console(&mut self, level: Level, message: &str) {
-        match level {
-          Level::Log => { js! { console.log(@{message}); } },
-          Level::Warn => { js! { console.warn(@{message}); } },
-          Level::Error => { js! { console.error(@{message}); } },
-        }
+    fn get_console(&self) -> Console {
+        Console {}
     }
 }

--- a/src/services/console.rs
+++ b/src/services/console.rs
@@ -9,7 +9,7 @@ impl Console {
     pub fn error(&self, message: &str) { js! { console.error(@{message}); } }
     pub fn debug(&self, message: &str) { js! { console.debug(@{message}); } }
     pub fn count_named(&self, name: &str) { js! { console.count(@{name}); } }
-    pub fn count(&self, name: &str) { js! { console.count(); } }
+    pub fn count(&self) { js! { console.count(); } }
 
     pub fn time_named(&self, name: &str) { js! { console.time(@{name}); } }
     pub fn time_named_end(&self, name: &str) { js! { console.timeEnd(@{name}); } }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -14,5 +14,3 @@ fn to_ms(duration: Duration) -> u32 {
     let ms = duration.subsec_nanos() / 1_000_000;
     ms + duration.as_secs() as u32 * 1000
 }
-
-


### PR DESCRIPTION
Addresses #44 

Also refactored the way `ConsoleService` works. It now creates an instance of `Console`, which itself can do (almost) everything the JS console can do.

I had to name some functions `{function}_named` or similar because Rust doesn't have function arity overloading, which I did not realize until today!

I find this methodology to be a bit more ergonomic than the currently implemented one. Definitely willing to hear criticism, though. I'm very new to Rust. =)