### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 repository = "https://github.com/DenisKolodin/yew"
 homepage = "https://github.com/DenisKolodin/yew"


### PR DESCRIPTION
Version 0.1.0 released and a new release sprint started.
Yew now available on crates: https://crates.io/crates/yew/0.1.0
But there are a lot of things we will improve in 0.2.0.
