### PR TITLE
Implement PartialEq for VTag

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -127,9 +127,9 @@ pub fn unpack<MSG>(mut stack: Stack<MSG>) -> VTag<MSG> {
 }
 
 #[doc(hidden)]
-pub fn set_value<MSG, T: ToString>(stack: &mut Stack<MSG>, value: &T) {
+pub fn set_value<MSG, T: ToString>(stack: &mut Stack<MSG>, value: T) {
     if let Some(node) = stack.last_mut() {
-        node.set_value(value);
+        node.set_value(&value);
     } else {
         panic!("no tag to set value: {}", value.to_string());
     }

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -1,6 +1,7 @@
 //! This module contains the implementation of abstract virtual node.
 
 use std::fmt;
+use std::cmp::PartialEq;
 use stdweb::web::{INode, Node, Element, TextNode, document};
 use virtual_dom::{VTag, VText, Messages};
 
@@ -174,6 +175,29 @@ impl<MSG> fmt::Debug for VNode<MSG> {
         match self {
             &VNode::VTag { ref vtag, .. } => vtag.fmt(f),
             &VNode::VText { ref vtext, .. } => vtext.fmt(f),
+        }
+    }
+}
+
+impl<MSG> PartialEq for VNode<MSG> {
+    fn eq(&self, other: &VNode<MSG>) -> bool {
+        match *self {
+            VNode::VTag { vtag: ref vtag_a, .. } => {
+                match *other {
+                    VNode::VTag { vtag: ref vtag_b, .. } => {
+                        vtag_a == vtag_b
+                    },
+                    _ => false
+                }
+            },
+            VNode::VText { vtext: ref vtext_a, .. } => {
+                match *other {
+                    VNode::VText { vtext: ref vtext_b, .. } => {
+                        vtext_a == vtext_b
+                    },
+                    _ => false
+                }
+            }
         }
     }
 }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -3,6 +3,7 @@
 use std::fmt;
 use std::borrow::Cow;
 use std::collections::HashSet;
+use std::cmp::PartialEq;
 use stdweb::web::{IElement, Element, EventListenerHandle};
 use stdweb::web::html_element::InputElement;
 use stdweb::unstable::TryFrom;
@@ -303,4 +304,60 @@ fn remove_attribute(element: &Element, name: &str) {
 /// Set `checked` value for the `InputElement`.
 fn set_checked(input: &InputElement, value: bool) {
     js!( @{input}.checked = @{value}; );
+}
+
+impl<MSG> PartialEq for VTag<MSG> {
+    fn eq(&self, other: &VTag<MSG>) -> bool {
+        if self.tag != other.tag {
+            return false;
+        }
+
+        if self.value != other.value {
+            return false;
+        }
+
+        if self.kind != other.kind {
+            return false;
+        }
+
+        if self.checked != other.checked {
+            return false;
+        }
+
+        if self.listeners.len() != other.listeners.len() {
+            return false;
+        }
+
+        for i in 0..self.listeners.len() {
+            let a = &self.listeners[i];
+            let b = &other.listeners[i];
+
+            if a.kind() != b.kind() {
+                return false;
+            }
+        }
+
+        if self.attributes != other.attributes {
+            return false;
+        }
+
+        if self.classes != other.classes {
+            return false;
+        }
+
+        if self.childs.len() != other.childs.len() {
+            return false;
+        }
+
+        for i in 0..self.childs.len() {
+            let a = &self.childs[i];
+            let b = &other.childs[i];
+
+            if a != b {
+                return false;
+            }
+        }
+
+        true
+    }
 }

--- a/src/virtual_dom/vtext.rs
+++ b/src/virtual_dom/vtext.rs
@@ -1,6 +1,7 @@
 //! This module contains the implementation of a virtual text node `VText`.
 
 use std::fmt;
+use std::cmp::PartialEq;
 use stdweb::web::{INode, TextNode};
 
 /// A type for a virtual
@@ -36,3 +37,8 @@ impl fmt::Debug for VText {
     }
 }
 
+impl PartialEq for VText {
+    fn eq(&self, other: &VText) -> bool {
+        return self.text == other.text;
+    }
+}

--- a/tests/vtag_test.rs
+++ b/tests/vtag_test.rs
@@ -1,0 +1,154 @@
+#[macro_use]
+extern crate yew;
+
+use yew::virtual_dom::VTag;
+
+#[test]
+fn it_compares_tags() {
+    let a: VTag<()> = html! {
+        <div></div>
+    };
+
+    let b: VTag<()> = html! {
+        <div></div>
+    };
+
+    let c: VTag<()> = html! {
+        <p></p>
+    };
+
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+}
+
+#[test]
+fn it_compares_text() {
+    let a: VTag<()> = html! {
+        <div>{ "correct" }</div>
+    };
+
+    let b: VTag<()> = html! {
+        <div>{ "correct" }</div>
+    };
+
+    let c: VTag<()> = html! {
+        <div>{ "incorrect" }</div>
+    };
+
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+}
+
+#[test]
+fn it_compares_attributes() {
+    let a: VTag<()> = html! {
+        <div a="test",></div>
+    };
+
+    let b: VTag<()> = html! {
+        <div a="test",></div>
+    };
+
+    let c: VTag<()> = html! {
+        <div a="fail",></div>
+    };
+
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+}
+
+#[test]
+fn it_compares_children() {
+    let a: VTag<()> = html! {
+        <div>
+            <p></p>
+        </div>
+    };
+
+    let b: VTag<()> = html! {
+        <div>
+            <p></p>
+        </div>
+    };
+
+    let c: VTag<()> = html! {
+        <div>
+            <span></span>
+        </div>
+    };
+
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+}
+
+#[test]
+fn it_compares_classes() {
+    let a: VTag<()> = html! {
+        <div class="test",></div>
+    };
+
+    let b: VTag<()> = html! {
+        <div class="test",></div>
+    };
+
+    let c: VTag<()> = html! {
+        <div class="fail",></div>
+    };
+
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+}
+
+#[test]
+fn it_compares_values() {
+    let a: VTag<()> = html! {
+        <input value="test",/>
+    };
+
+    let b: VTag<()> = html! {
+        <input value="test",/>
+    };
+
+    let c: VTag<()> = html! {
+        <input value="fail",/>
+    };
+
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+}
+
+#[test]
+fn it_compares_kinds() {
+    let a: VTag<()> = html! {
+        <input type="text",/>
+    };
+
+    let b: VTag<()> = html! {
+        <input type="text",/>
+    };
+
+    let c: VTag<()> = html! {
+        <input type="hidden",/>
+    };
+
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+}
+
+#[test]
+fn it_compares_checked() {
+    let a: VTag<()> = html! {
+        <input type="checkbox", checked=false,/>
+    };
+
+    let b: VTag<()> = html! {
+        <input type="checkbox", checked=false,/>
+    };
+
+    let c: VTag<()> = html! {
+        <input type="checkbox", checked=true,/>
+    };
+
+    assert_eq!(a, b);
+    assert_ne!(a, c);
+}


### PR DESCRIPTION
Implements `std::cmp::PartialEq` for `VTag`, which will allow for creating tests against the virtual dom. Includes a small suite of tests for the comparison functionality.

Since these are the first tests for yew, I wasn't sure what test organization you would want, but I went with the separate `tests/` folder convention, let me know if you want to change it.

I also made a change to how `set_value` works in `macros.rs` because it wasn't actually accepting values like

```rust
html! {
  <input value="test",/>
}
```

as it couldn't size the `str`. It seemed from the inline documentation that this was the intended usage, so I changed it to work like the `set_attributes` method, but perhaps this is wrong?