### PR TITLE
Make tag field public again

### DIFF
--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -14,7 +14,7 @@ use virtual_dom::{Messages, Listener, Listeners, Classes, Attributes, Patch, VNo
 /// representation.
 pub struct VTag<MSG> {
     /// A tag of the element.
-    tag: Cow<'static, str>,
+    pub tag: Cow<'static, str>,
     /// List of attached listeners.
     pub listeners: Listeners<MSG>,
     /// List of attributes.


### PR DESCRIPTION
I've made `tag` public again, it's maybe a temporary fix till I will found better solution for #67 
