### PR TITLE
Use storage in TodoMVC example

### DIFF
--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -6,4 +6,6 @@ authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 [dependencies]
 strum = "0.8.0"
 strum_macros = "0.8.0"
+serde = "1"
+serde_derive = "1"
 yew = { path = "../.." }

--- a/examples/todomvc/README.md
+++ b/examples/todomvc/README.md
@@ -1,0 +1,6 @@
+## Yew TodoMVC Demo
+
+This it an implementationt of [TodoMVC](http://todomvc.com/) app.
+
+Unlike other implementations, this stores the full state of the model in the storage,
+including: all entries, entered text and choosed filter.


### PR DESCRIPTION
This PR adds `localStorage` support to TodoMVC example, but stores the model completely.
Related #76 