### PR TITLE
Run tests in headless Chrome for Emscripten backends

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: rust
 
 dist: trusty
 sudo: false
+addons:
+  chrome: stable
 
 rust:
   - stable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,7 @@ description = "A framework for making client-side single-page apps"
 serde = "1"
 serde_json = "1"
 stdweb = "0.3"
+
+[features]
+default = []
+web_test = []

--- a/ci.sh
+++ b/ci.sh
@@ -29,19 +29,20 @@ cargo install cargo-web -f
 if [ "$TARGET" = "asmjs-unknown-emscripten" ]; then
     rustup target add asmjs-unknown-emscripten
     export CARGO_WEB_ARGS="--target-asmjs-emscripten"
+    cargo web test --features web_test $CARGO_WEB_ARGS
 fi
 
 if [ "$TARGET" = "wasm32-unknown-emscripten" ]; then
     rustup target add wasm32-unknown-emscripten
     export CARGO_WEB_ARGS="--target-webasm-emscripten"
+    cargo web test --features web_test $CARGO_WEB_ARGS
 fi
 
 if [ "$TARGET" = "wasm32-unknown-unknown" ]; then
     rustup target add wasm32-unknown-unknown
     export CARGO_WEB_ARGS="--target-webasm"
+    cargo web test --nodejs $CARGO_WEB_ARGS
 fi
-
-cargo web test --nodejs $CARGO_WEB_ARGS
 
 check_example() {
     echo "Checking example [$1]"


### PR DESCRIPTION
This makes it possible to write tests which use browser-only APIs.

For any such tests it will be a good idea to put them in their own namespace and gate them on the `web_test` feature so that running other tests which *don't* require a Web browser will still work under Node.js.
```
#[cfg(all(test, feature = "web_test"))]
mod tests {
    // Tests go in here.
}
```
