### PR TITLE
Fix a bunch of typos

### DIFF
--- a/examples/npm_and_rest/src/gravatar.rs
+++ b/examples/npm_and_rest/src/gravatar.rs
@@ -14,14 +14,14 @@ pub struct Entry {
     hash: String,
     request_hash: String,
     profile_url: String,
-    preffered_username: String,
+    preferred_username: String,
 }
 
-pub struct GavatarService<MSG> {
+pub struct GravatarService<MSG> {
     web: FetchService<MSG>,
 }
 
-impl<MSG: 'static> GavatarService<MSG> {
+impl<MSG: 'static> GravatarService<MSG> {
     pub fn new(sender: AppSender<MSG>) -> Self {
         Self {
             web: FetchService::new(sender),

--- a/examples/npm_and_rest/src/main.rs
+++ b/examples/npm_and_rest/src/main.rs
@@ -8,13 +8,13 @@ extern crate yew;
 use yew::html::*;
 
 // Own services implementation
-mod gavatar;
-use gavatar::{GavatarService, Profile};
+mod gravatar;
+use gravatar::{GravatarService, Profile};
 mod ccxt;
 use ccxt::CcxtService;
 
 struct Context {
-    gavatar: GavatarService<Msg>,
+    gravatar: GravatarService<Msg>,
     ccxt: CcxtService,
 }
 
@@ -24,21 +24,21 @@ struct Model {
 }
 
 enum Msg {
-    Gavatar,
-    GavatarReady(Result<Profile, ()>),
+    Gravatar,
+    GravatarReady(Result<Profile, ()>),
     Exchanges,
 }
 
 fn update(context: &mut Context, model: &mut Model, msg: Msg) {
     match msg {
-        Msg::Gavatar => {
-            context.gavatar.profile("205e460b479e2e5b48aec07710c08d50", Msg::GavatarReady);
+        Msg::Gravatar => {
+            context.gravatar.profile("205e460b479e2e5b48aec07710c08d50", Msg::GravatarReady);
         }
-        Msg::GavatarReady(Ok(profile)) => {
+        Msg::GravatarReady(Ok(profile)) => {
             model.profile = Some(profile);
         }
-        Msg::GavatarReady(Err(_)) => {
-            // Can't load gavatar profile
+        Msg::GravatarReady(Err(_)) => {
+            // Can't load gravatar profile
         }
         Msg::Exchanges => {
             model.exchanges = context.ccxt.exchanges();
@@ -53,7 +53,7 @@ fn view(model: &Model) -> Html<Msg> {
     html! {
         <div>
             <button onclick=|_| Msg::Exchanges,>{ "Get Exchanges" }</button>
-            <button onclick=|_| Msg::Gavatar,>{ "Get Gavatar" }</button>
+            <button onclick=|_| Msg::Gravatar,>{ "Get Gravatar" }</button>
             <ul>
                 { for model.exchanges.iter().map(view_exchange) }
             </ul>
@@ -64,7 +64,7 @@ fn view(model: &Model) -> Html<Msg> {
 fn main() {
     let mut app = App::new();
     let context = Context {
-        gavatar: GavatarService::new(app.sender()),
+        gravatar: GravatarService::new(app.sender()),
         ccxt: CcxtService::new(),
     };
     let model = Model {


### PR DESCRIPTION
Not sure if I'm missing something, but there were a lot of typos (including Gavatar, as opposed to Gravatar) in examples/npm_and_rest. Kind of weirded me out, so here's a PR. Let me know if I'm just confused. It's been a long day.

BTW neither master nor this works for me due to CORS. Not sure how to fix it, if it's fixable at all.