### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ fn update(context: &mut Context, model: &mut Model, msg: Msg) {
 
 ### Easy-to-use data conversion and destructuring
 
-You could simply choose and use a format of data to store/send and resore/receive it.
+You could simply choose and use a format of data to store/send and restore/receive it.
 
 Supported: `JSON`
 
@@ -164,7 +164,7 @@ fn update(context: &mut Context, model: &mut Model, msg: Msg) {
 Clone or download this repository.
 
 There are seven examples to check how it works:
-[counter], [timer], [todomvc], [game_of_life], [crm], [dashboard], [npm_and_rest].
+[counter], [timer], [todomvc], [game_of_life], [crm], [dashboard] and [npm_and_rest].
 
 To run them you need to have [cargo-web] installed as well as a suitable target
 for the Rust compiler to generate web output. By default cargo-web uses
@@ -181,7 +181,6 @@ To start an example enter its directory start it with [cargo-web]:
 To run an optimised build instead of a debug build use:
 
     $ cargo web start --release
-
 
 [counter]: examples/counter
 [timer]: examples/timer

--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -28,7 +28,7 @@ fn update(context: &mut Context, model: &mut Model, msg: Msg) {
         }
         Msg::Decrement => {
             model.value = model.value - 1;
-            context.console.log("munis one");
+            context.console.log("minus one");
         }
         Msg::Bulk(list) => {
             for msg in list {

--- a/examples/crm/src/main.rs
+++ b/examples/crm/src/main.rs
@@ -110,7 +110,7 @@ fn update(context: &mut Context, model: &mut Model, msg: Msg) {
                     new_scene = Some(Scene::ClientsList);
                 }
                 unexpected => {
-                    panic!("Unexpected message diring new client editing: {:?}", unexpected);
+                    panic!("Unexpected message during new client editing: {:?}", unexpected);
                 }
             }
         }

--- a/examples/dashboard/README.md
+++ b/examples/dashboard/README.md
@@ -2,7 +2,7 @@
 
 ## Build and run the client
 
-Enter to `client` folder and run:
+Enter the `client` folder and run:
 
 ```sh
 cargo web start

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -34,7 +34,7 @@ fn update(context: &mut Context, model: &mut Model, msg: Msg) {
             model.job = Some(Box::new(handle));
             model.messages.clear();
             context.console.clear();
-            model.messages.push("Timer started!!");
+            model.messages.push("Timer started!");
             context.console.time_named("Timer");
         }
         Msg::StartInterval => {

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -170,7 +170,7 @@ fn view_entry((idx, entry): (usize, &Entry)) -> Html<Msg> {
             <div class="view",>
                 <input class="toggle", type="checkbox", checked=entry.completed, onclick=move|_| Msg::Toggle(idx), />
                 <label ondoubleclick=move|_| Msg::ToggleEdit(idx),>{ &entry.description }</label>
-                <button class="destroy", onclick=move |_| Msg::Remove(idx),></button>
+                <button class="destroy", onclick=move |_| Msg::Remove(idx), />
             </div>
             { view_entry_edit_input((idx, &entry)) }
         </li>

--- a/src/html.rs
+++ b/src/html.rs
@@ -152,7 +152,7 @@ macro_rules! impl_action {
 
                 fn attach(&mut self, element: &Element, messages: Messages<MSG>)
                     -> EventListenerHandle {
-                    let handler = self.0.take().expect("tried to attach lostener twice");
+                    let handler = self.0.take().expect("tried to attach listener twice");
                     let this = element.clone();
                     let sender = move |event: $type| {
                         debug!("Event handler: {}", stringify!($type));
@@ -196,7 +196,7 @@ impl_action! {
     oninput(event: InputEvent) -> InputData => |this: &Element, _| {
         use stdweb::web::html_element::InputElement;
         use stdweb::unstable::TryInto;
-        let input: InputElement = this.clone().try_into().expect("only InputElement could have oninput event listener");
+        let input: InputElement = this.clone().try_into().expect("only an InputElement can have an oninput event listener");
         let value = input.value().into_string().unwrap_or_else(|| "".into());
         InputData { value }
     }
@@ -205,24 +205,24 @@ impl_action! {
 /// A type representing data from `onclick` and `ondoubleclick` event.
 #[derive(Debug)]
 pub struct MouseData {
-    /// The screenX read-only property of the
+    /// The screenX is a read-only property of the
     /// [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/screenX)
-    /// property provides the horizontal coordinate (offset)
+    /// property which provides the horizontal coordinate (offset)
     /// of the mouse pointer in global (screen) coordinates.
     pub screen_x: f64,
-    /// The screenY read-only property of the
+    /// The screenY is a read-only property of the
     /// [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/screenY)
-    /// property provides the vertical coordinate (offset)
+    /// property which provides the vertical coordinate (offset)
     /// of the mouse pointer in global (screen) coordinates.
     pub screen_y: f64,
-    /// The clientX read-only property of the
+    /// The clientX is a read-only property of the
     /// [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientX)
-    /// interface provides the horizontal coordinate within
+    /// interface which provides the horizontal coordinate within
     /// the application's client area at which the event occurred
     pub client_x: f64,
-    /// The clientY read-only property of the
+    /// The clientY is a read-only property of the
     /// [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientX)
-    /// interface provides the vertical coordinate within
+    /// interface which provides the vertical coordinate within
     /// the application's client area at which the event occurred
     pub client_y: f64,
 }


### PR DESCRIPTION
While looking thru examples, I fixed various typos and made an element self-closing.

