### PR TITLE
Use typed Request/Response objects in Fetch Service

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["gui", "web-programming"]
 description = "A framework for making client-side single-page apps"
 
 [dependencies]
+http = "0.1"
 serde = "1"
 serde_json = "1"
 stdweb = "0.3"

--- a/examples/dashboard/client/src/main.rs
+++ b/examples/dashboard/client/src/main.rs
@@ -6,7 +6,7 @@ extern crate yew;
 use yew::html::*;
 use yew::format::{Nothing, Json};
 use yew::services::Task;
-use yew::services::fetch::{FetchService, Method};
+use yew::services::fetch::{FetchService, Request};
 use yew::services::websocket::{WebSocketService, WebSocketHandle, WebSocketStatus};
 
 struct Context {
@@ -71,7 +71,17 @@ fn update(context: &mut Context, model: &mut Model, msg: Msg) {
     match msg {
         Msg::FetchData => {
             model.fetching = true;
-            context.web.fetch(Method::Get, "./data.json", Nothing, |Json(data)| Msg::FetchReady(data));
+            context.web.fetch(
+                Request::get("/data.json").body(Nothing).unwrap(),
+                |response| {
+                    let (meta, Json(data)) = response.into_parts();
+                    if meta.status.is_success() {
+                        Msg::FetchReady(data)
+                    } else {
+                        Msg::Ignore  // FIXME: Handle this error accordingly.
+                    }
+                }
+            );
         }
         Msg::WsAction(action) => {
             match action {

--- a/examples/npm_and_rest/src/gravatar.rs
+++ b/examples/npm_and_rest/src/gravatar.rs
@@ -1,5 +1,5 @@
 use yew::format::{Nothing, Json};
-use yew::services::fetch::{FetchService, FetchHandle, Method};
+use yew::services::fetch::{FetchService, FetchHandle, Request};
 use yew::html::AppSender;
 
 #[derive(Deserialize, Debug)]
@@ -32,8 +32,13 @@ impl<MSG: 'static> GravatarService<MSG> {
     where
         F: Fn(Result<Profile, ()>) -> MSG + 'static
     {
-        let url = format!("https://www.gravatar.com/{}.json", hash);
-        let handler = move |Json(data)| { listener(data) };
-        self.web.fetch(Method::Get, &url, Nothing, handler)
+        let url = format!("https://gravatar.com/{}", hash);
+        self.web.fetch(
+            Request::get(url.as_str()).body(Nothing)
+                                      .unwrap(),
+        move |response| {
+            let (_, Json(data)) = response.into_parts();
+            listener(data)
+        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@
 )]
 #![recursion_limit="256"]
 
+extern crate http;
 extern crate serde;
 extern crate serde_json;
 #[macro_use]


### PR DESCRIPTION
Proposes the use of typed Request and Response objects as an interface for the Fetch API using the [http](https://github.com/hyperium/http) crate.

Fixes #66 among other issues such as support for other HTTP methods (other than GET and POST), reading status codes and response headers.
  