### PR TITLE
Allow html attributes with dash

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -72,6 +72,11 @@ macro_rules! html_impl {
         $crate::macros::add_attribute(&mut $stack, stringify!($attr), $val);
         html_impl! { $stack ($($tail)*) }
     };
+    ($stack:ident ($($attr:ident)-+ = $val:expr, $($tail:tt)*)) => {
+        let attr = vec![$(stringify!($attr).to_string()),+].join("-");
+        $crate::macros::add_attribute(&mut $stack, &attr, $val);
+        html_impl! { $stack ($($tail)*) }
+    };
     // PATTERN: { for expression }
     ($stack:ident ({ for $eval:expr } $($tail:tt)*)) => {
         let nodes = $eval;
@@ -154,7 +159,7 @@ pub fn set_checked<MSG>(stack: &mut Stack<MSG>, value: bool) {
 }
 
 #[doc(hidden)]
-pub fn add_attribute<MSG, T: ToString>(stack: &mut Stack<MSG>, name: &'static str, value: T) {
+pub fn add_attribute<MSG, T: ToString>(stack: &mut Stack<MSG>, name: &str, value: T) {
     if let Some(node) = stack.last_mut() {
         node.add_attribute(name, value);
     } else {

--- a/tests/vtag_test.rs
+++ b/tests/vtag_test.rs
@@ -152,3 +152,30 @@ fn it_compares_checked() {
     assert_eq!(a, b);
     assert_ne!(a, c);
 }
+
+#[test]
+fn it_allows_aria_attributes() {
+    let a: VTag<()> = html! {
+        <p aria-controls="it-works",>
+            <a class="btn btn-primary",
+               data-toggle="collapse",
+               href="#collapseExample",
+               role="button",
+               aria-expanded="false",
+               aria-controls="collapseExample",>
+                { "Link with href" }
+            </a>
+            <button class="btn btn-primary",
+                    type="button",
+                    data-toggle="collapse",
+                    data-target="#collapseExample",
+                    aria-expanded="false",
+                    aria-controls="collapseExample",>
+                { "Button with data-target" }
+            </button>
+            <div own-attribute-with-multiple-parts="works", />
+        </p>
+    };
+    assert!(a.attributes.contains_key("aria-controls"));
+    assert_eq!(a.attributes.get("aria-controls"), Some(&"it-works".into()));
+}


### PR DESCRIPTION
This patch allow us to add attributes with dash, like:

```html
<button class="btn", class="btn-primary", class="btn-block",
        type="button", data-toggle="collapse", data-target={ &target },
        aria-expanded="false", aria-controls="collapseExample",>
    { "expand" }
</button>

<div class="collapse", id={id}, >
    <div class="card", class="card-body",>
        { "Anim pariatur cliche reprehenderit, enim eiusmod high life accusamus terry richardson ad squid. Nihil anim keffiyeh helvetica, craft beer labore wes anderson cred nesciunt sapiente ea proident. "}
    </div>
</div>

```

I'm making a web with bootstrap and with the current version I can't do this:
https://getbootstrap.com/docs/4.0/components/collapse/

This patch solves the problem.