### PR TITLE
Fix entry text removal on enter in todomvc, add onblur event

### DIFF
--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -79,6 +79,7 @@ fn update(context: &mut Context, model: &mut Model, msg: Msg) {
             model.filter = filter;
         }
         Msg::ToggleEdit(idx) => {
+            model.edit_value = model.entries[idx].description.clone();
             model.toggle_edit(idx);
         }
         Msg::ToggleAll => {
@@ -184,6 +185,7 @@ fn view_entry_edit_input((idx, entry): (usize, &Entry)) -> Html<Msg> {
                    type="text",
                    value=&entry.description,
                    oninput=|e: InputData| Msg::UpdateEdit(e.value),
+                   onblur=move|_| Msg::Edit(idx),
                    onkeypress=move |e: KeyData| {
                       if e.key == "Enter" { Msg::Edit(idx) } else { Msg::Nope }
                    }, />

--- a/src/html.rs
+++ b/src/html.rs
@@ -197,6 +197,10 @@ impl_action! {
     onmouseover(event: MouseOverEvent) -> () => |_, _| { () }
     onmouseout(event: MouseOutEvent) -> () => |_, _| { () }
     */
+    onblur(event: BlurEvent) -> BlurEvent => |_, event| {
+        use stdweb::web::event::BlurEvent;
+        BlurEvent::from(event)
+    }
     oninput(event: InputEvent) -> InputData => |this: &Element, _| {
         use stdweb::web::html_element::InputElement;
         use stdweb::unstable::TryInto;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -54,6 +54,9 @@ macro_rules! html_impl {
     ($stack:ident (oninput = $handler:expr, $($tail:tt)*)) => {
         html_impl! { $stack ((oninput) = $handler, $($tail)*) }
     };
+    ($stack:ident (onblur = $handler:expr, $($tail:tt)*)) => {
+        html_impl! { $stack ((onblur) = $handler, $($tail)*) }
+    };
     // PATTERN: (action)=expression,
     ($stack:ident (($action:ident) = $handler:expr, $($tail:tt)*)) => {
         // Catch value to a separate variable for clear error messages


### PR DESCRIPTION
Fixes https://github.com/DenisKolodin/yew/issues/99 by resetting the edit_value string to the entry description when enter key is pressed without making changes. Thanks @coder543!

Adds `onblur` event to prevent multiple simultaneous edit mode on multiple entries, removes the need to add a vector of values being edited... partially....

The input field needs to be autofocused, maybe we should intercept/match on an `autoFocus=""` attribute, and automatically focus on the element when it's rendered ([like React](https://github.com/facebook/react/blob/ac630e4a2f2a6e794c3f9858f606476147e735fd/packages/react-dom/src/client/ReactDOM.js#L719))?