### PR TITLE
use (no_return) optimization on js! macros

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -35,7 +35,7 @@ impl<MSG> AppSender<MSG> {
     pub fn send(&mut self, msg: MSG) {
         self.tx.send(msg).expect("App lost the receiver!");
         let bind = &self.bind;
-        js! {
+        js! { @(no_return)
             // Schedule to call the loop handler
             // IMPORTANT! If call loop function immediately
             // it stops handling other messages and the first
@@ -120,7 +120,7 @@ impl<MSG: 'static> App<MSG> {
         };
         // Initial call for first rendering
         callback();
-        js! {
+        js! { @(no_return)
             var bind = @{bind};
             var callback = @{callback};
             bind.loop = callback;

--- a/src/services/console.rs
+++ b/src/services/console.rs
@@ -7,71 +7,71 @@ pub struct ConsoleService;
 impl ConsoleService {
     /// [console.log](https://developer.mozilla.org/en-US/docs/Web/API/Console/log)
     /// method implementation.
-    pub fn log(&self, message: &str) { js! { console.log(@{message}); } }
+    pub fn log(&self, message: &str) { js! { @(no_return) console.log(@{message}); } }
 
     /// [console.warn](https://developer.mozilla.org/en-US/docs/Web/API/Console/warn)
     /// method implementation.
-    pub fn warn(&self, message: &str) { js! { console.warn(@{message}); } }
+    pub fn warn(&self, message: &str) { js! { @(no_return) console.warn(@{message}); } }
 
     /// [console.info](https://developer.mozilla.org/en-US/docs/Web/API/Console/info)
     /// method implementation.
-    pub fn info(&self, message: &str) { js! { console.info(@{message}); } }
+    pub fn info(&self, message: &str) { js! { @(no_return) console.info(@{message}); } }
 
     /// [console.error](https://developer.mozilla.org/en-US/docs/Web/API/Console/error)
     /// method implementation.
-    pub fn error(&self, message: &str) { js! { console.error(@{message}); } }
+    pub fn error(&self, message: &str) { js! { @(no_return) console.error(@{message}); } }
 
     /// [console.debug](https://developer.mozilla.org/en-US/docs/Web/API/Console/debug)
     /// method implementation.
-    pub fn debug(&self, message: &str) { js! { console.debug(@{message}); } }
+    pub fn debug(&self, message: &str) { js! { @(no_return) console.debug(@{message}); } }
 
     /// [console.count_named](https://developer.mozilla.org/en-US/docs/Web/API/Console/count_named)
     /// method implementation.
-    pub fn count_named(&self, name: &str) { js! { console.count(@{name}); } }
+    pub fn count_named(&self, name: &str) { js! { @(no_return) console.count(@{name}); } }
 
     /// [console.count](https://developer.mozilla.org/en-US/docs/Web/API/Console/count)
     /// method implementation.
-    pub fn count(&self) { js! { console.count(); } }
+    pub fn count(&self) { js! { @(no_return) console.count(); } }
 
 
     /// [console.time_named](https://developer.mozilla.org/en-US/docs/Web/API/Console/time_named)
     /// method implementation.
-    pub fn time_named(&self, name: &str) { js! { console.time(@{name}); } }
+    pub fn time_named(&self, name: &str) { js! { @(no_return) console.time(@{name}); } }
 
     /// [console.time_named_end](https://developer.mozilla.org/en-US/docs/Web/API/Console/time_named_end)
     /// method implementation.
-    pub fn time_named_end(&self, name: &str) { js! { console.timeEnd(@{name}); } }
+    pub fn time_named_end(&self, name: &str) { js! { @(no_return) console.timeEnd(@{name}); } }
 
 
     /// [console.time](https://developer.mozilla.org/en-US/docs/Web/API/Console/time)
     /// method implementation.
-    pub fn time(&self) { js! { console.time(); } }
+    pub fn time(&self) { js! { @(no_return) console.time(); } }
     /// [console.time_end](https://developer.mozilla.org/en-US/docs/Web/API/Console/time_end)
     /// method implementation.
-    pub fn time_end(&self) { js! { console.timeEnd(); } }
+    pub fn time_end(&self) { js! { @(no_return) console.timeEnd(); } }
 
 
     /// [console.clear](https://developer.mozilla.org/en-US/docs/Web/API/Console/clear)
     /// method implementation.
-    pub fn clear(&self) { js! { console.clear(); } }
+    pub fn clear(&self) { js! { @(no_return) console.clear(); } }
 
     /// [console.group](https://developer.mozilla.org/en-US/docs/Web/API/Console/group)
     /// method implementation.
-    pub fn group(&self) { js! { console.group(); } }
+    pub fn group(&self) { js! { @(no_return) console.group(); } }
 
     /// [console.group_collapsed](https://developer.mozilla.org/en-US/docs/Web/API/Console/group_collapsed)
     /// method implementation.
-    pub fn group_collapsed(&self) { js! { console.groupCollapsed(); } }
+    pub fn group_collapsed(&self) { js! { @(no_return) console.groupCollapsed(); } }
 
     /// [console.group_end](https://developer.mozilla.org/en-US/docs/Web/API/Console/group_end)
     /// method implementation.
-    pub fn group_end(&self) { js! { console.groupEnd(); } }
+    pub fn group_end(&self) { js! { @(no_return) console.groupEnd(); } }
 
     /// [console.trace](https://developer.mozilla.org/en-US/docs/Web/API/Console/trace)
     /// method implementation.
-    pub fn trace(&self) { js! { console.trace(); } }
+    pub fn trace(&self) { js! { @(no_return) console.trace(); } }
 
     /// [console.assert](https://developer.mozilla.org/en-US/docs/Web/API/Console/assert)
     /// method implementation.
-    pub fn assert(&self, condition: bool, message: &str) { js! { console.assert(@{condition}, @{message}); } }
+    pub fn assert(&self, condition: bool, message: &str) { js! { @(no_return) console.assert(@{condition}, @{message}); } }
 }

--- a/src/services/dialog.rs
+++ b/src/services/dialog.rs
@@ -9,7 +9,7 @@ pub struct DialogService;
 impl DialogService {
     /// Calls [alert](https://developer.mozilla.org/en-US/docs/Web/API/Window/alert)
     /// function.
-    pub fn alert(&mut self, message: &str) { js! { alert(@{message}); } }
+    pub fn alert(&mut self, message: &str) { js! { @(no_return) alert(@{message}); } }
 
     /// Calls [confirm](https://developer.mozilla.org/en-US/docs/Web/API/Window/confirm)
     /// function.

--- a/src/services/fetch.rs
+++ b/src/services/fetch.rs
@@ -177,7 +177,7 @@ impl Task for FetchHandle {
         // and we should use this workaround with a flag.
         // In fact, request not canceled, but callback won't be called.
         let handle = self.0.take().expect("tried to cancel request fetching twice");
-        js! {
+        js! {  @(no_return)
             var handle = @{handle};
             handle.interrupted = true;
             handle.callback.drop();

--- a/src/services/interval.rs
+++ b/src/services/interval.rs
@@ -51,7 +51,7 @@ impl<MSG: 'static> IntervalService<MSG> {
 impl Task for IntervalHandle {
     fn cancel(&mut self) {
         let handle = self.0.take().expect("tried to cancel interval twice");
-        js! {
+        js! { @(no_return)
             var handle = @{handle};
             clearInterval(handle.interval_id);
             handle.callback.drop();

--- a/src/services/storage.rs
+++ b/src/services/storage.rs
@@ -31,8 +31,12 @@ impl StorageService {
     {
         if let Some(data) = value.into() {
             match self.scope {
-                Scope::Local => { js! { localStorage.setItem(@{key}, @{data}); } },
-                Scope::Session => { js! { sessionStorage.setItem(@{key}, @{data}); } },
+                Scope::Local => { js! { @(no_return)
+                    localStorage.setItem(@{key}, @{data});
+                } },
+                Scope::Session => { js! { @(no_return)
+                    sessionStorage.setItem(@{key}, @{data});
+                } },
             }
         }
     }
@@ -56,8 +60,12 @@ impl StorageService {
     pub fn remove(&mut self, key: &str) {
         {
             match self.scope {
-                Scope::Local => js! { localStorage.removeItem(@{key}); },
-                Scope::Session => js! { sessionStorage.removeItem(@{key}); },
+                Scope::Local => js! { @(no_return)
+                    localStorage.removeItem(@{key});
+                },
+                Scope::Session => js! { @(no_return)
+                    sessionStorage.removeItem(@{key});
+                },
             }
         };
     }

--- a/src/services/timeout.rs
+++ b/src/services/timeout.rs
@@ -50,7 +50,7 @@ impl<MSG: 'static> TimeoutService<MSG> {
 impl Task for TimeoutHandle {
     fn cancel(&mut self) {
         let handle = self.0.take().expect("tried to cancel timeout twice");
-        js! {
+        js! { @(no_return)
             var handle = @{handle};
             clearTimeout(handle.timeout_id);
             handle.callback.drop();

--- a/src/services/websocket.rs
+++ b/src/services/websocket.rs
@@ -88,7 +88,7 @@ impl WebSocketHandle {
     {
         if let WebSocketHandle(Some(ref handle)) = *self {
             if let Some(body) = data.into() {
-                js! {
+                js! { @(no_return)
                     var handle = @{handle};
                     handle.socket.send(@{body});
                 }
@@ -102,7 +102,7 @@ impl WebSocketHandle {
 impl Task for WebSocketHandle {
     fn cancel(&mut self) {
         let handle = self.0.take().expect("tried to close websocket twice");
-        js! {
+        js! { @(no_return)
             var handle = @{handle};
             handle.socket.close();
         }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -290,17 +290,17 @@ impl<MSG> fmt::Debug for VTag<MSG> {
 /// `stdweb` doesn't have methods to work with attributes now.
 /// this is workaround from: https://github.com/koute/stdweb/issues/16#issuecomment-325195854
 fn set_attribute(element: &Element, name: &str, value: &str) {
-    js!( @{element}.setAttribute( @{name}, @{value} ); );
+    js!( @(no_return) @{element}.setAttribute( @{name}, @{value} ); );
 }
 
 /// Removes attribute from a element by name.
 fn remove_attribute(element: &Element, name: &str) {
-    js!( @{element}.removeAttribute( @{name} ); );
+    js!( @(no_return) @{element}.removeAttribute( @{name} ); );
 }
 
 /// Set `checked` value for the `InputElement`.
 fn set_checked(input: &InputElement, value: bool) {
-    js!( @{input}.checked = @{value}; );
+    js!( @(no_return) @{input}.checked = @{value}; );
 }
 
 impl<MSG> PartialEq for VTag<MSG> {


### PR DESCRIPTION
This removes the serialization overhead when calling a js! macro which the return value is not used.

Related to https://github.com/koute/stdweb/issues/73.