### PR TITLE
Use `peekable` to check if filtered iterator is none or not

### DIFF
--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -255,10 +255,16 @@ impl Model {
     }
 
     fn is_all_completed(&self) -> bool {
-        self.entries
-            .iter()
-            .filter(|e| self.filter.fit(e))
-            .all(|e| e.completed)
+        let mut filtered_iter = self.entries
+                                    .iter()
+                                    .filter(|e| self.filter.fit(e))
+                                    .peekable();
+
+        if filtered_iter.peek().is_none() {
+            return false;
+        }
+
+        filtered_iter.all(|e| e.completed)
     }
 
     fn toggle_all(&mut self, value: bool) {


### PR DESCRIPTION
@DenisKolodin 
cc @kamek-pf

Sorry for that I didn't notice `empty` iterator will return true when using `all` method from `iter` in #105 .

This PR will fix the issue for empty iterator. Thanks.