### PR TITLE
Workaround IoVec upstream issue introduced by of Fetch implementation

### DIFF
--- a/examples/counter/Cargo.toml
+++ b/examples/counter/Cargo.toml
@@ -6,3 +6,8 @@ authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 [dependencies]
 chrono = "0.4.0"
 yew = { path = "../.." }
+
+# Necessary until IoVec cuts a new release supporting Wasm
+# More info: https://github.com/DenisKolodin/yew/issues/102
+[replace]
+"iovec:0.1.1" = { git = 'https://github.com/machineloop/iovec', branch = 'wasm-support' }

--- a/examples/crm/Cargo.toml
+++ b/examples/crm/Cargo.toml
@@ -7,3 +7,8 @@ authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 serde = "1"
 serde_derive = "1"
 yew = { path = "../.." }
+
+# Necessary until IoVec cuts a new release supporting Wasm
+# More info: https://github.com/DenisKolodin/yew/issues/102
+[replace]
+"iovec:0.1.1" = { git = 'https://github.com/machineloop/iovec', branch = 'wasm-support' }

--- a/examples/custom_components/Cargo.toml
+++ b/examples/custom_components/Cargo.toml
@@ -5,3 +5,8 @@ authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 
 [dependencies]
 yew = { path = "../.." }
+
+# Necessary until IoVec cuts a new release supporting Wasm
+# More info: https://github.com/DenisKolodin/yew/issues/102
+[replace]
+"iovec:0.1.1" = { git = 'https://github.com/machineloop/iovec', branch = 'wasm-support' }

--- a/examples/dashboard/client/Cargo.toml
+++ b/examples/dashboard/client/Cargo.toml
@@ -7,3 +7,8 @@ authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 serde = "1"
 serde_derive = "1"
 yew = { path = "../../.." }
+
+# Necessary until IoVec cuts a new release supporting Wasm
+# More info: https://github.com/DenisKolodin/yew/issues/102
+[replace]
+"iovec:0.1.1" = { git = 'https://github.com/machineloop/iovec', branch = 'wasm-support' }

--- a/examples/game_of_life/Cargo.toml
+++ b/examples/game_of_life/Cargo.toml
@@ -6,3 +6,8 @@ authors = ["Diego Cardoso <dige0card0s0@hotmail.com>"]
 [dependencies]
 yew = { path = "../.." }
 rand = "0.4.1"
+
+# Necessary until IoVec cuts a new release supporting Wasm
+# More info: https://github.com/DenisKolodin/yew/issues/102
+[replace]
+"iovec:0.1.1" = { git = 'https://github.com/machineloop/iovec', branch = 'wasm-support' }

--- a/examples/mount_point/Cargo.toml
+++ b/examples/mount_point/Cargo.toml
@@ -6,3 +6,8 @@ authors = ["Ben Berman <ben@standardbots.com>"]
 [dependencies]
 yew = { path = "../.." }
 stdweb = "0.3"
+
+# Necessary until IoVec cuts a new release supporting Wasm
+# More info: https://github.com/DenisKolodin/yew/issues/102
+[replace]
+"iovec:0.1.1" = { git = 'https://github.com/machineloop/iovec', branch = 'wasm-support' }

--- a/examples/npm_and_rest/Cargo.toml
+++ b/examples/npm_and_rest/Cargo.toml
@@ -8,3 +8,8 @@ serde = "1"
 serde_derive = "1"
 yew = { path = "../.." }
 stdweb = "0.3"
+
+# Necessary until IoVec cuts a new release supporting Wasm
+# More info: https://github.com/DenisKolodin/yew/issues/102
+[replace]
+"iovec:0.1.1" = { git = 'https://github.com/machineloop/iovec', branch = 'wasm-support' }

--- a/examples/timer/Cargo.toml
+++ b/examples/timer/Cargo.toml
@@ -5,3 +5,8 @@ authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 
 [dependencies]
 yew = { path = "../.." }
+
+# Necessary until IoVec cuts a new release supporting Wasm
+# More info: https://github.com/DenisKolodin/yew/issues/102
+[replace]
+"iovec:0.1.1" = { git = 'https://github.com/machineloop/iovec', branch = 'wasm-support' }

--- a/examples/todomvc/Cargo.toml
+++ b/examples/todomvc/Cargo.toml
@@ -9,3 +9,8 @@ strum_macros = "0.8.0"
 serde = "1"
 serde_derive = "1"
 yew = { path = "../.." }
+
+# Necessary until IoVec cuts a new release supporting Wasm
+# More info: https://github.com/DenisKolodin/yew/issues/102
+[replace]
+"iovec:0.1.1" = { git = 'https://github.com/machineloop/iovec', branch = 'wasm-support' }

--- a/examples/two_apps/Cargo.toml
+++ b/examples/two_apps/Cargo.toml
@@ -6,3 +6,8 @@ authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 [dependencies]
 stdweb = "0.3"
 yew = { path = "../.." }
+
+# Necessary until IoVec cuts a new release supporting Wasm
+# More info: https://github.com/DenisKolodin/yew/issues/102
+[replace]
+"iovec:0.1.1" = { git = 'https://github.com/machineloop/iovec', branch = 'wasm-support' }


### PR DESCRIPTION
Master is broken for `wasm32-unknown-unknown` builds because of the Fetch implementation's use of `Http` Request/Response return types. @DenisKolodin, we can avoid backing out Fetch's use of Http if we do something along the lines of this PR.

See https://github.com/DenisKolodin/yew/issues/102 for more info, IoVec needs to cut a new release supporting Wasm and `From<[u8]> impls`.

> There was a breaking change to remove the From<[u8]> impls that will be released with a version-bump eventually.

We can add these lines of code temporarily in the examples to pull a version of IoVec directly from my Github fork which cherry picks the commits that support Wasm while leaving out the breaking changes to the `From<[u8]> impls`.

Perhaps there's a more elegant way to do this without using `[replace]` in the `cargo.toml` files.