### PR TITLE
Remove unnecessary encloding div

### DIFF
--- a/examples/custom_components/src/barrier.rs
+++ b/examples/custom_components/src/barrier.rs
@@ -64,7 +64,7 @@ impl<CTX: 'static> Component<CTX> for Barrier {
 impl<CTX: 'static> Renderable<CTX, Barrier> for Barrier {
     fn view(&self) -> Html<CTX, Self> {
         html! {
-            <div>
+            <div class="barrier",>
                 <p>{ format!("{} on {} clicked", self.counter, self.limit) }</p>
                 <Button: onsignal=|_| Msg::ChildClicked, />
                 <Button: onsignal=|_| Msg::ChildClicked, />

--- a/examples/custom_components/src/counter.rs
+++ b/examples/custom_components/src/counter.rs
@@ -19,6 +19,7 @@ pub enum Msg {
 
 #[derive(PartialEq, Clone)]
 pub struct Props {
+    pub initial: u32,
     pub color: Color,
     pub onclick: Option<Callback<u32>>,
 }
@@ -26,6 +27,7 @@ pub struct Props {
 impl Default for Props {
     fn default() -> Self {
         Props {
+            initial: 0,
             color: Color::Green,
             onclick: None,
         }
@@ -58,6 +60,9 @@ impl<CTX: Printer + 'static> Component<CTX> for Counter {
     }
 
     fn change(&mut self, props: Self::Properties, _: &mut Env<CTX, Self>) -> ShouldRender {
+        if self.value == 0 {
+            self.value = props.initial;
+        }
         self.color = props.color;
         self.onclick = props.onclick;
         true
@@ -74,7 +79,7 @@ impl<CTX: Printer + 'static> Renderable<CTX, Counter> for Counter {
             }
         };
         html! {
-            <div>
+            <div class="couter",>
                 <p>{ self.value }</p>
                 <button style=colorize, onclick=|_| Msg::Increase,>{ "Increase internal counter" }</button>
             </div>

--- a/examples/custom_components/src/main.rs
+++ b/examples/custom_components/src/main.rs
@@ -23,11 +23,13 @@ impl counter::Printer for Context {
 }
 
 struct Model {
+    with_barrier: bool,
     color: Color,
 }
 
 enum Msg {
     Repaint,
+    Toggle,
     ChildClicked(u32),
 }
 
@@ -37,6 +39,7 @@ impl Component<Context> for Model {
 
     fn create(_: &mut Env<Context, Self>) -> Self {
         Model {
+            with_barrier: false,
             color: Color::Red,
         }
     }
@@ -45,6 +48,10 @@ impl Component<Context> for Model {
         match msg {
             Msg::Repaint => {
                 self.color = Color::Blue;
+                true
+            }
+            Msg::Toggle => {
+                self.with_barrier = !self.with_barrier;
                 true
             }
             Msg::ChildClicked(value) => {
@@ -57,14 +64,29 @@ impl Component<Context> for Model {
 
 impl Renderable<Context, Model> for Model {
     fn view(&self) -> Html<Context, Self> {
-        let counter = |_| html! {
-            <Counter: color=&self.color, onclick=Msg::ChildClicked,/>
+        let counter = |x| html! {
+            <Counter: initial=x, color=&self.color, onclick=Msg::ChildClicked,/>
         };
         html! {
-            <div>
-                <Barrier: limit=10, onsignal=|_| Msg::Repaint, />
-                { for (0..1000).map(counter) }
+            <div class="custom-components-example",>
+                <button onclick=|_| Msg::Toggle,>{ "Toggle" }</button>
+                { self.view_barrier() }
+                { for (1..1001).map(counter) }
             </div>
+        }
+    }
+}
+
+impl Model {
+    fn view_barrier(&self) -> Html<Context, Self> {
+        if self.with_barrier {
+            html! {
+                <Barrier: limit=10, onsignal=|_| Msg::Repaint, />
+            }
+        } else {
+            html! {
+                <p>{ "Click \"toggle\"!" }</p>
+            }
         }
     }
 }

--- a/src/html.rs
+++ b/src/html.rs
@@ -10,7 +10,7 @@ use std::sync::mpsc::{Sender, Receiver, channel};
 use stdweb::Value;
 use stdweb::web::{Element, INode, Node, EventListenerHandle, document};
 use stdweb::web::event::{IMouseEvent, IKeyboardEvent, BlurEvent};
-use virtual_dom::{VNode, Listener};
+use virtual_dom::{VDiff, VNode, Listener};
 
 /// This type indicates that component should be rendered again.
 pub type ShouldRender = bool;

--- a/src/html.rs
+++ b/src/html.rs
@@ -283,8 +283,13 @@ where
     /// function in Elm. You should provide an initial model, `update` function
     /// which will update the state of the model and a `view` function which
     /// will render the model to a virtual DOM tree.
-    pub fn mount(mut self, element: Element) {
+    pub fn mount(self, element: Element) {
         clear_element(&element);
+        self.mount_in_place(element, None);
+    }
+
+    /// Mounts elements in place of previous node.
+    pub fn mount_in_place(mut self, element: Element, obsolete: Option<VNode<CTX, COMP>>) {
         let mut component = {
             let mut env = self.get_env();
             let mut scope_ref = env.get_ref();
@@ -294,7 +299,7 @@ where
         let mut updates = Vec::new();
         let mut last_frame = VNode::from(component.view());
         // First-time rendering the tree
-        last_frame.apply(&element, None, self.get_env());
+        last_frame.apply(&element, obsolete, self.get_env());
         let mut last_frame = Some(last_frame);
         let rx = self.rx.take().expect("application runned without a receiver");
         let bind = self.bind.clone();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,7 +83,7 @@ pub fn initialize() {
             var limit = 25;
             var callback = pool.pop();
             while (callback !== undefined) {
-                callback();
+                callback.loop();
                 limit = limit - 1;
                 if (limit > 0) {
                     callback = pool.pop();

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -159,7 +159,7 @@ pub fn unpack<CTX, COMP: Component<CTX>>(mut stack: Stack<CTX, COMP>) -> VNode<C
 
 #[doc(hidden)]
 pub fn set_value<CTX, COMP: Component<CTX>, T: ToString>(stack: &mut Stack<CTX, COMP>, value: T) {
-    if let Some(&mut VNode::VTag{ ref mut vtag, .. }) = stack.last_mut() {
+    if let Some(&mut VNode::VTag(ref mut vtag)) = stack.last_mut() {
         vtag.set_value(&value);
     } else {
         panic!("no tag to set value: {}", value.to_string());
@@ -168,7 +168,7 @@ pub fn set_value<CTX, COMP: Component<CTX>, T: ToString>(stack: &mut Stack<CTX, 
 
 #[doc(hidden)]
 pub fn set_kind<CTX, COMP: Component<CTX>, T: ToString>(stack: &mut Stack<CTX, COMP>, value: T) {
-    if let Some(&mut VNode::VTag{ ref mut vtag, .. }) = stack.last_mut() {
+    if let Some(&mut VNode::VTag(ref mut vtag)) = stack.last_mut() {
         vtag.set_kind(value);
     } else {
         panic!("no tag to set type: {}", value.to_string());
@@ -177,7 +177,7 @@ pub fn set_kind<CTX, COMP: Component<CTX>, T: ToString>(stack: &mut Stack<CTX, C
 
 #[doc(hidden)]
 pub fn set_checked<CTX, COMP: Component<CTX>>(stack: &mut Stack<CTX, COMP>, value: bool) {
-    if let Some(&mut VNode::VTag{ ref mut vtag, .. }) = stack.last_mut() {
+    if let Some(&mut VNode::VTag(ref mut vtag)) = stack.last_mut() {
         vtag.set_checked(value);
     } else {
         panic!("no tag to set checked: {}", value);
@@ -186,7 +186,7 @@ pub fn set_checked<CTX, COMP: Component<CTX>>(stack: &mut Stack<CTX, COMP>, valu
 
 #[doc(hidden)]
 pub fn add_attribute<CTX, COMP: Component<CTX>, T: ToString>(stack: &mut Stack<CTX, COMP>, name: &str, value: T) {
-    if let Some(&mut VNode::VTag{ ref mut vtag, .. }) = stack.last_mut() {
+    if let Some(&mut VNode::VTag(ref mut vtag)) = stack.last_mut() {
         vtag.add_attribute(name, value);
     } else {
         panic!("no tag to set attribute: {}", name);
@@ -195,7 +195,7 @@ pub fn add_attribute<CTX, COMP: Component<CTX>, T: ToString>(stack: &mut Stack<C
 
 #[doc(hidden)]
 pub fn attach_class<CTX, COMP: Component<CTX>>(stack: &mut Stack<CTX, COMP>, class: &'static str) {
-    if let Some(&mut VNode::VTag{ ref mut vtag, .. }) = stack.last_mut() {
+    if let Some(&mut VNode::VTag(ref mut vtag)) = stack.last_mut() {
         vtag.add_classes(class);
     } else {
         panic!("no tag to attach class: {}", class);
@@ -204,7 +204,7 @@ pub fn attach_class<CTX, COMP: Component<CTX>>(stack: &mut Stack<CTX, COMP>, cla
 
 #[doc(hidden)]
 pub fn attach_listener<CTX, COMP: Component<CTX>>(stack: &mut Stack<CTX, COMP>, listener: Box<Listener<CTX, COMP>>) {
-    if let Some(&mut VNode::VTag{ ref mut vtag, .. }) = stack.last_mut() {
+    if let Some(&mut VNode::VTag(ref mut vtag)) = stack.last_mut() {
         vtag.add_listener(listener);
     } else {
         panic!("no tag to attach listener: {:?}", listener);
@@ -213,7 +213,7 @@ pub fn attach_listener<CTX, COMP: Component<CTX>>(stack: &mut Stack<CTX, COMP>, 
 
 #[doc(hidden)]
 pub fn add_child<CTX, COMP: Component<CTX>>(stack: &mut Stack<CTX, COMP>, child: VNode<CTX, COMP>) {
-    if let Some(&mut VNode::VTag{ ref mut vtag, .. }) = stack.last_mut() {
+    if let Some(&mut VNode::VTag(ref mut vtag)) = stack.last_mut() {
         vtag.add_child(child);
     } else {
         panic!("no nodes in stack to add child: {:?}", child);
@@ -223,14 +223,14 @@ pub fn add_child<CTX, COMP: Component<CTX>>(stack: &mut Stack<CTX, COMP>, child:
 #[doc(hidden)]
 pub fn child_to_parent<CTX, COMP: Component<CTX>>(stack: &mut Stack<CTX, COMP>, endtag: Option<&'static str>) {
     if let Some(mut node) = stack.pop() {
-        if let (&mut VNode::VTag { ref mut vtag, .. }, Some(endtag)) = (&mut node, endtag) {
+        if let (&mut VNode::VTag(ref mut vtag), Some(endtag)) = (&mut node, endtag) {
             let starttag = vtag.tag();
             if starttag != endtag {
                 panic!("wrong closing tag: <{}> -> </{}>", starttag, endtag);
             }
         }
         if !stack.is_empty() {
-            if let Some(&mut VNode::VTag{ ref mut vtag, ..}) = stack.last_mut() {
+            if let Some(&mut VNode::VTag(ref mut vtag)) = stack.last_mut() {
                 vtag.add_child(node);
             } else {
                 panic!("can't add child to this type of node");

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -7,13 +7,13 @@ pub mod vcomp;
 
 use std::fmt;
 use std::collections::{HashMap, HashSet};
-use stdweb::web::{Element, EventListenerHandle};
+use stdweb::web::{Node, Element, EventListenerHandle};
 
 pub use self::vnode::VNode;
 pub use self::vtag::VTag;
 pub use self::vtext::VText;
 pub use self::vcomp::VComp;
-use html::{ScopeSender, Component};
+use html::{ScopeSender, ScopeEnv, Component};
 
 /// `Listener` trait is an universal implementation of an event listener
 /// which helps to bind Rust-listener to JS-listener (DOM).
@@ -47,3 +47,24 @@ enum Patch<ID, T> {
     Remove(ID),
 }
 
+// TODO What about to implement `VDiff` for `Element`?
+// In makes possible to include ANY element into the tree.
+// `Ace` editor embedding for example?
+
+/// This trait provides features to update a tree by other tree comparsion.
+pub trait VDiff {
+    /// The context where this instance live.
+    type Context;
+    /// The component which this instance put into.
+    type Component: Component<Self::Context>;
+
+    /// Get binded node.
+    fn get_node(&self) -> Option<Node>;
+    /// Remove itself from parent.
+    fn remove(self, parent: &Element);
+    /// Scoped diff apply to other tree.
+    fn apply(&mut self,
+             parent: &Element,
+             opposite: Option<VNode<Self::Context, Self::Component>>,
+             scope: ScopeEnv<Self::Context, Self::Component>);
+}

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -12,6 +12,8 @@ struct Hidden;
 /// A virtual component.
 pub struct VComp<CTX, COMP: Component<CTX>> {
     type_id: TypeId,
+    /// A reference to the `Element`.
+    pub reference: Option<Element>,
     props: Option<(TypeId, *mut Hidden)>,
     blind_sender: Box<FnMut((TypeId, *mut Hidden))>,
     generator: Box<FnMut(SharedContext<CTX>, Element)>,
@@ -52,6 +54,7 @@ impl<CTX: 'static, COMP: Component<CTX>> VComp<CTX, COMP> {
         let properties = Default::default();
         let comp = VComp {
             type_id: TypeId::of::<CHILD>(),
+            reference: None,
             props: None,
             blind_sender: Box::new(blind_sender),
             generator: Box::new(generator),

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -86,9 +86,9 @@ impl<CTX: 'static, COMP: Component<CTX>> VComp<CTX, COMP> {
     /// This methods gives sender from older node.
     pub(crate) fn grab_sender_of(&mut self, other: Self) {
         assert_eq!(self.type_id, other.type_id);
-        // Grab a sender to reuse it later
+        // Grab a sender and a cell (element's reference) to reuse it later
         self.blind_sender = other.blind_sender;
-        //self.reference = other.reference;
+        self.cell = other.cell;
     }
 }
 

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::any::TypeId;
-use stdweb::web::{Node, Element};
+use stdweb::web::{INode, Node, Element};
 use virtual_dom::VNode;
 use html::{ScopeBuilder, SharedContext, Component, Renderable, ComponentUpdate, ScopeSender, Callback, ScopeEnv, NodeCell};
 
@@ -160,8 +160,10 @@ where
     }
 
     /// Remove VComp from parent.
-    pub fn remove(self, _: &Element) {
-        unimplemented!();
+    pub fn remove(self, parent: &Element) {
+        if let Some(node) = self.get_node() {
+            parent.remove_child(&node).expect("can't remove the component");
+        }
     }
 
     /// This methods mount a virtual component with a generator created with `lazy` call.

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -20,6 +20,24 @@ pub enum VNode<CTX, COMP: Component<CTX>> {
 
 
 impl<CTX: 'static, COMP: Component<CTX>> VNode<CTX, COMP> {
+    /// Get binded node.
+    pub fn get_node(&self) -> Option<Node> {
+        match *self {
+            VNode::VTag(ref vtag) => {
+                vtag.get_node()
+            },
+            VNode::VText(ref vtext) => {
+                vtext.get_node()
+            },
+            VNode::VComp(ref vcomp) => {
+                vcomp.get_node()
+            },
+            VNode::VRef(ref node) => {
+                Some(node.to_owned())
+            },
+        }
+    }
+
     /// Remove VNode from parent.
     pub fn remove(self, parent: &Element) {
         match self {

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -2,252 +2,78 @@
 
 use std::fmt;
 use std::cmp::PartialEq;
-use stdweb::web::{INode, Node, Element, TextNode, document};
+use stdweb::web::{INode, Node, Element};
 use virtual_dom::{VTag, VText, VComp};
 use html::{ScopeEnv, Component, Renderable};
 
 /// Bind virtual element to a DOM reference.
 pub enum VNode<CTX, COMP: Component<CTX>> {
     /// A bind between `VTag` and `Element`.
-    VTag {
-        /// A reference to the `Element`.
-        reference: Option<Element>,
-        /// A virtual tag node which was applied.
-        vtag: VTag<CTX, COMP>,
-    },
+    VTag(VTag<CTX, COMP>),
     /// A bind between `VText` and `TextNode`.
-    VText {
-        /// A reference to the `TextNode`.
-        reference: Option<TextNode>,
-        /// A virtual text node which was applied.
-        vtext: VText<CTX, COMP>,
-    },
+    VText(VText<CTX, COMP>),
     /// A bind between `VComp` and `Element`.
-    VComp {
-        /// A reference to the `Element`.
-        reference: Option<Element>,
-        /// A virtual component which will be applied to the `Element`.
-        vcomp: VComp<CTX, COMP>,
-    },
+    VComp(VComp<CTX, COMP>),
+    /// A holder for any `Node` (necessary for replacing node).
+    VRef(Node),
 }
 
 
 impl<CTX: 'static, COMP: Component<CTX>> VNode<CTX, COMP> {
     /// Remove VNode from parent.
-    pub fn remove<T: INode>(self, parent: &T) {
-        let opt_ref: Option<Node> = {
-            match self {
-                VNode::VTag { reference, .. } => reference.map(Node::from),
-                VNode::VText { reference, .. } => reference.map(Node::from),
-                VNode::VComp { reference, .. } => reference.map(Node::from),
-            }
-        };
-        if let Some(node) = opt_ref {
-            if let Err(_) = parent.remove_child(&node) {
-                warn!("Node not found to remove: {:?}", node);
-            }
+    pub fn remove(self, parent: &Element) {
+        match self {
+            VNode::VTag(vtag) => vtag.remove(parent),
+            VNode::VText(vtext) => vtext.remove(parent),
+            VNode::VComp(vcomp) => vcomp.remove(parent),
+            VNode::VRef(node) => {
+                parent.remove_child(&node).expect("can't remove node by VRef")
+            },
         }
     }
 
     /// Virtual rendering for the node. It uses parent node and existend children (virtual and DOM)
     /// to check the difference and apply patches to the actual DOM represenatation.
-    pub fn apply<T: INode>(&mut self, parent: &T, opposite: Option<VNode<CTX, COMP>>, env: ScopeEnv<CTX, COMP>) {
+    pub fn apply(&mut self, parent: &Element, opposite: Option<VNode<CTX, COMP>>, env: ScopeEnv<CTX, COMP>) {
         match *self {
-            VNode::VTag { ref mut vtag, .. } => {
+            VNode::VTag(ref mut vtag) => {
                 vtag.apply(parent, opposite, env);
             }
-            VNode::VText { ref mut vtext, .. } => {
+            VNode::VText(ref mut vtext) => {
                 vtext.apply(parent, opposite, env);
             }
-            VNode::VComp { ref mut vcomp, .. } => {
+            VNode::VComp(ref mut vcomp) => {
+                vcomp.apply(parent, opposite, env);
+            }
+            VNode::VRef(_) => {
+                // TODO use it for rendering any tag
+                unimplemented!("node can't be rendered now");
             }
         }
-
-    /*
-    pub fn apply<T: INode>(&mut self, parent: &T, last: Option<VNode<CTX, COMP>>, env: ScopeEnv<CTX, COMP>) {
-        match *self {
-            VNode::VTag {
-                ref mut vtag,
-                ref mut reference,
-            } => {
-                let left = vtag;
-                let mut right = None;
-                match last {
-                    Some(VNode::VTag {
-                             vtag,
-                             reference: Some(element),
-                         }) => {
-                        // Copy reference from right to left (as is)
-                        if left.tag() == vtag.tag() {
-                            right = Some(vtag);
-                            *reference = Some(element);
-                        } else {
-                            let wrong = element;
-                            let element = document().create_element(left.tag());
-                            parent.replace_child(&element, &wrong);
-                            *reference = Some(element);
-                        }
-                    }
-                    Some(VNode::VText { reference: Some(wrong), .. }) => {
-                        let element = document().create_element(left.tag());
-                        parent.replace_child(&element, &wrong);
-                        *reference = Some(element);
-                    }
-                    Some(VNode::VComp { reference: Some(wrong), .. }) => {
-                        let element = document().create_element(left.tag());
-                        parent.replace_child(&element, &wrong);
-                        *reference = Some(element);
-                    }
-                    Some(VNode::VTag { reference: None, .. }) |
-                    Some(VNode::VText { reference: None, .. }) |
-                    Some(VNode::VComp { reference: None, .. }) |
-                    None => {
-                        let element = document().create_element(left.tag());
-                        parent.append_child(&element);
-                        *reference = Some(element);
-                    }
-                }
-                let element_mut = reference.as_mut().expect("vtag must be here");
-                // Update parameters
-                let mut rights = {
-                    if let Some(ref mut right) = right {
-                        right.childs.drain(..).map(Some).collect::<Vec<_>>()
-                    } else {
-                        Vec::new()
-                    }
-                };
-                left.render(element_mut, right, env.clone());
-                let mut lefts = left.childs.iter_mut().map(Some).collect::<Vec<_>>();
-                // Process children
-                let diff = lefts.len() as i32 - rights.len() as i32;
-                if diff > 0 {
-                    for _ in 0..diff {
-                        rights.push(None);
-                    }
-                } else if diff < 0 {
-                    for _ in 0..-diff {
-                        lefts.push(None);
-                    }
-                }
-                for pair in lefts.into_iter().zip(rights) {
-                    match pair {
-                        (Some(left), right) => {
-                            left.apply(element_mut, right, env.clone());
-                        }
-                        (None, Some(right)) => {
-                            right.remove(element_mut);
-                        }
-                        (None, None) => {
-                            panic!("redundant iterations during diff");
-                        }
-                    }
-                }
-            }
-            VNode::VText {
-                ref mut vtext,
-                ref mut reference,
-            } => {
-                let left = vtext;
-                let mut right = None;
-                match last {
-                    Some(VNode::VText {
-                             vtext,
-                             reference: Some(element),
-                         }) => {
-                        right = Some(vtext);
-                        *reference = Some(element);
-                    }
-                    Some(VNode::VTag { reference: Some(wrong), .. }) |
-                    Some(VNode::VComp { reference: Some(wrong), .. }) => {
-                        let element = document().create_text_node(&left.text);
-                        parent.replace_child(&element, &wrong);
-                        *reference = Some(element);
-                    }
-                    Some(VNode::VTag { reference: None, .. }) |
-                    Some(VNode::VText { reference: None, .. }) |
-                    Some(VNode::VComp { reference: None, .. }) |
-                    None => {
-                        let element = document().create_text_node(&left.text);
-                        parent.append_child(&element);
-                        *reference = Some(element);
-                    }
-                }
-                let element_mut = reference.as_mut().expect("vtext must be here");
-                left.render(element_mut, right);
-            }
-            VNode::VComp {
-                ref mut vcomp,
-                ref mut reference,
-            } => {
-                let left = vcomp;
-                let mut right = None;
-                match last {
-                    Some(VNode::VComp {
-                             vcomp,
-                             reference: Some(element),
-                         }) => {
-                        if *left == vcomp {
-                            // Send fresh properties to an active component
-                            right = Some(vcomp);
-                            *reference = Some(element);
-                        } else {
-                            let wrong = element;
-                            let element = document().create_element("div");
-                            parent.replace_child(&element, &wrong);
-                            *reference = Some(element);
-                        }
-                    }
-                    Some(VNode::VComp { reference: None, .. }) |
-                    None => {
-                        let element = document().create_element("div");
-                        parent.append_child(&element);
-                        *reference = Some(element);
-                    }
-                    _ => {
-                        eprintln!("Diff not implemented for components");
-                    }
-                }
-                let element_mut = reference.as_mut().expect("vcomp must be here");
-                left.render(element_mut, right, env.clone());
-            }
-        }
-    */
     }
 }
 
 impl<CTX, COMP: Component<CTX>> From<VText<CTX, COMP>> for VNode<CTX, COMP> {
     fn from(vtext: VText<CTX, COMP>) -> Self {
-        VNode::VText {
-            reference: None,
-            vtext,
-        }
+        VNode::VText(vtext)
     }
 }
 
 impl<CTX, COMP: Component<CTX>> From<VTag<CTX, COMP>> for VNode<CTX, COMP> {
     fn from(vtag: VTag<CTX, COMP>) -> Self {
-        VNode::VTag {
-            reference: None,
-            vtag,
-        }
+        VNode::VTag(vtag)
     }
 }
 
 impl<CTX, COMP: Component<CTX>> From<VComp<CTX, COMP>> for VNode<CTX, COMP> {
     fn from(vcomp: VComp<CTX, COMP>) -> Self {
-        VNode::VComp {
-            reference: None,
-            vcomp,
-        }
+        VNode::VComp(vcomp)
     }
 }
 
 impl<CTX: 'static, COMP: Component<CTX>, T: ToString> From<T> for VNode<CTX, COMP> {
     fn from(value: T) -> Self {
-        VNode::VText {
-            reference: None,
-            vtext: VText::new(value.to_string()),
-        }
+        VNode::VText(VText::new(value.to_string()))
     }
 }
 
@@ -260,9 +86,10 @@ impl<'a, CTX, COMP: Component<CTX>> From<&'a Renderable<CTX, COMP>> for VNode<CT
 impl<CTX, COMP: Component<CTX>> fmt::Debug for VNode<CTX, COMP> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            &VNode::VTag { ref vtag, .. } => vtag.fmt(f),
-            &VNode::VText { ref vtext, .. } => vtext.fmt(f),
-            &VNode::VComp { .. } => "Component<>".fmt(f),
+            &VNode::VTag(ref vtag) => vtag.fmt(f),
+            &VNode::VText(ref vtext) => vtext.fmt(f),
+            &VNode::VComp(_) => "Component<>".fmt(f),
+            &VNode::VRef(_) => "NodeReference<>".fmt(f),
         }
     }
 }
@@ -270,23 +97,28 @@ impl<CTX, COMP: Component<CTX>> fmt::Debug for VNode<CTX, COMP> {
 impl<CTX, COMP: Component<CTX>> PartialEq for VNode<CTX, COMP> {
     fn eq(&self, other: &VNode<CTX, COMP>) -> bool {
         match *self {
-            VNode::VTag { vtag: ref vtag_a, .. } => {
+            VNode::VTag(ref vtag_a) => {
                 match *other {
-                    VNode::VTag { vtag: ref vtag_b, .. } => {
+                    VNode::VTag(ref vtag_b) => {
                         vtag_a == vtag_b
                     },
                     _ => false
                 }
             }
-            VNode::VText { vtext: ref vtext_a, .. } => {
+            VNode::VText(ref vtext_a) => {
                 match *other {
-                    VNode::VText { vtext: ref vtext_b, .. } => {
+                    VNode::VText(ref vtext_b) => {
                         vtext_a == vtext_b
                     },
                     _ => false
                 }
             }
-            VNode::VComp { .. } => {
+            VNode::VComp(_) => {
+                // TODO Implement it
+                false
+            }
+            VNode::VRef(_) => {
+                // TODO Implement it
                 false
             }
         }

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -3,8 +3,8 @@
 use std::fmt;
 use std::cmp::PartialEq;
 use stdweb::web::{INode, Node, Element};
-use virtual_dom::{VTag, VText, VComp};
 use html::{ScopeEnv, Component, Renderable};
+use super::{VDiff, VTag, VText, VComp};
 
 /// Bind virtual element to a DOM reference.
 pub enum VNode<CTX, COMP: Component<CTX>> {
@@ -19,9 +19,12 @@ pub enum VNode<CTX, COMP: Component<CTX>> {
 }
 
 
-impl<CTX: 'static, COMP: Component<CTX>> VNode<CTX, COMP> {
+impl<CTX: 'static, COMP: Component<CTX>> VDiff for VNode<CTX, COMP> {
+    type Context = CTX;
+    type Component = COMP;
+
     /// Get binded node.
-    pub fn get_node(&self) -> Option<Node> {
+    fn get_node(&self) -> Option<Node> {
         match *self {
             VNode::VTag(ref vtag) => {
                 vtag.get_node()
@@ -39,7 +42,7 @@ impl<CTX: 'static, COMP: Component<CTX>> VNode<CTX, COMP> {
     }
 
     /// Remove VNode from parent.
-    pub fn remove(self, parent: &Element) {
+    fn remove(self, parent: &Element) {
         match self {
             VNode::VTag(vtag) => vtag.remove(parent),
             VNode::VText(vtext) => vtext.remove(parent),
@@ -52,7 +55,7 @@ impl<CTX: 'static, COMP: Component<CTX>> VNode<CTX, COMP> {
 
     /// Virtual rendering for the node. It uses parent node and existend children (virtual and DOM)
     /// to check the difference and apply patches to the actual DOM represenatation.
-    pub fn apply(&mut self, parent: &Element, opposite: Option<VNode<CTX, COMP>>, env: ScopeEnv<CTX, COMP>) {
+    fn apply(&mut self, parent: &Element, opposite: Option<VNode<Self::Context, Self::Component>>, env: ScopeEnv<Self::Context, Self::Component>) {
         match *self {
             VNode::VTag(ref mut vtag) => {
                 vtag.apply(parent, opposite, env);

--- a/src/virtual_dom/vtext.rs
+++ b/src/virtual_dom/vtext.rs
@@ -3,9 +3,9 @@
 use std::fmt;
 use std::cmp::PartialEq;
 use std::marker::PhantomData;
-use stdweb::web::{INode, Node, Element, TextNode, document};
+use stdweb::web::{INode, Element, TextNode, document};
 use virtual_dom::{VTag, VNode, VComp};
-use html::{ScopeEnv, Component, Renderable};
+use html::{ScopeEnv, Component};
 
 /// A type for a virtual
 /// [TextNode](https://developer.mozilla.org/en-US/docs/Web/API/Document/createTextNode)
@@ -14,7 +14,7 @@ pub struct VText<CTX, COMP: Component<CTX>> {
     /// Contains a text of the node.
     pub text: String,
     /// A reference to the `Element`.
-    reference: Option<TextNode>,
+    pub reference: Option<TextNode>,
     _ctx: PhantomData<CTX>,
     _comp: PhantomData<COMP>,
 }
@@ -30,29 +30,41 @@ impl<CTX: 'static, COMP: Component<CTX>> VText<CTX, COMP> {
         }
     }
 
+    /// Remove VTag from parent.
+    pub fn remove(self, parent: &Element) {
+        let node = self.reference.expect("tried to remove not rendered VText from DOM");
+        if let Err(_) = parent.remove_child(&node) {
+            warn!("Node not found to remove VText");
+        }
+    }
+
     /// Renders virtual node over existent `TextNode`, but
     /// only if value of text had changed.
-    //pub fn render(&mut self, subject: &TextNode, opposite: Option<Self>) {
-    pub fn apply<T: INode>(&mut self, parent: &T, opposite: Option<VNode<CTX, COMP>>, env: ScopeEnv<CTX, COMP>) {
+    pub fn apply(&mut self, parent: &Element, opposite: Option<VNode<CTX, COMP>>, _: ScopeEnv<CTX, COMP>) {
         match opposite {
             // If element matched this type
-            Some(VNode::VText { vtext: VText { text, reference: Some(element), .. } , .. }) => {
+            Some(VNode::VText(VText { text, reference: Some(element), .. })) => {
                 if self.text != text {
                     element.set_node_value(Some(&self.text));
                 }
                 self.reference = Some(element);
             }
             // If element exists, but have a wrong type
-            Some(VNode::VTag { vtag: VTag { reference: Some(wrong), .. } , .. }) |
-            Some(VNode::VComp { vcomp: VComp { reference: Some(wrong), .. } , .. }) => {
+            Some(VNode::VTag(VTag { reference: Some(wrong), .. })) |
+            Some(VNode::VComp(VComp { reference: Some(wrong), .. })) => {
                 let element = document().create_text_node(&self.text);
                 parent.replace_child(&element, &wrong);
                 self.reference = Some(element);
             }
+            Some(VNode::VRef(node)) => {
+                let element = document().create_text_node(&self.text);
+                parent.replace_child(&element, &node);
+                self.reference = Some(element);
+            }
             // If element not exists
-            Some(VNode::VTag { vtag: VTag { reference: None, .. } , .. }) |
-            Some(VNode::VComp { vcomp: VComp { reference: None, .. } , .. }) |
-            Some(VNode::VText { vtext: VText { reference: None, .. } , .. }) |
+            Some(VNode::VTag(VTag { reference: None, .. })) |
+            Some(VNode::VComp(VComp { reference: None, .. })) |
+            Some(VNode::VText(VText { reference: None, .. })) |
             None => {
                 let element = document().create_text_node(&self.text);
                 parent.append_child(&element);

--- a/src/virtual_dom/vtext.rs
+++ b/src/virtual_dom/vtext.rs
@@ -2,43 +2,74 @@
 
 use std::fmt;
 use std::cmp::PartialEq;
-use stdweb::web::{INode, TextNode};
+use std::marker::PhantomData;
+use stdweb::web::{INode, Node, Element, TextNode, document};
+use virtual_dom::{VTag, VNode, VComp};
+use html::{ScopeEnv, Component, Renderable};
 
 /// A type for a virtual
 /// [TextNode](https://developer.mozilla.org/en-US/docs/Web/API/Document/createTextNode)
 /// represenation.
-pub struct VText {
+pub struct VText<CTX, COMP: Component<CTX>> {
     /// Contains a text of the node.
     pub text: String,
+    /// A reference to the `Element`.
+    reference: Option<TextNode>,
+    _ctx: PhantomData<CTX>,
+    _comp: PhantomData<COMP>,
 }
 
-impl VText {
+impl<CTX: 'static, COMP: Component<CTX>> VText<CTX, COMP> {
     /// Creates new virtual text node with a content.
     pub fn new(text: String) -> Self {
-        VText { text }
+        VText {
+            text,
+            reference: None,
+            _ctx: PhantomData,
+            _comp: PhantomData,
+        }
     }
 
     /// Renders virtual node over existent `TextNode`, but
     /// only if value of text had changed.
-    pub fn render(&mut self, subject: &TextNode, opposite: Option<Self>) {
-        if let Some(opposite) = opposite {
-            if self.text != opposite.text {
-                subject.set_node_value(Some(&self.text));
+    //pub fn render(&mut self, subject: &TextNode, opposite: Option<Self>) {
+    pub fn apply<T: INode>(&mut self, parent: &T, opposite: Option<VNode<CTX, COMP>>, env: ScopeEnv<CTX, COMP>) {
+        match opposite {
+            // If element matched this type
+            Some(VNode::VText { vtext: VText { text, reference: Some(element), .. } , .. }) => {
+                if self.text != text {
+                    element.set_node_value(Some(&self.text));
+                }
+                self.reference = Some(element);
             }
-        } else {
-            subject.set_node_value(Some(&self.text));
+            // If element exists, but have a wrong type
+            Some(VNode::VTag { vtag: VTag { reference: Some(wrong), .. } , .. }) |
+            Some(VNode::VComp { vcomp: VComp { reference: Some(wrong), .. } , .. }) => {
+                let element = document().create_text_node(&self.text);
+                parent.replace_child(&element, &wrong);
+                self.reference = Some(element);
+            }
+            // If element not exists
+            Some(VNode::VTag { vtag: VTag { reference: None, .. } , .. }) |
+            Some(VNode::VComp { vcomp: VComp { reference: None, .. } , .. }) |
+            Some(VNode::VText { vtext: VText { reference: None, .. } , .. }) |
+            None => {
+                let element = document().create_text_node(&self.text);
+                parent.append_child(&element);
+                self.reference = Some(element);
+            }
         }
     }
 }
 
-impl fmt::Debug for VText {
+impl<CTX, COMP: Component<CTX>> fmt::Debug for VText<CTX, COMP> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "VText {{ text: {} }}", self.text)
     }
 }
 
-impl PartialEq for VText {
-    fn eq(&self, other: &VText) -> bool {
+impl<CTX, COMP: Component<CTX>> PartialEq for VText<CTX, COMP> {
+    fn eq(&self, other: &VText<CTX, COMP>) -> bool {
         return self.text == other.text;
     }
 }

--- a/tests/vtag_test.rs
+++ b/tests/vtag_test.rs
@@ -200,7 +200,7 @@ fn it_allows_aria_attributes() {
             <div own-attribute-with-multiple-parts="works", />
         </p>
     };
-    if let VNode::VTag { vtag, .. } = a {
+    if let VNode::VTag(vtag) = a {
         assert!(vtag.attributes.contains_key("aria-controls"));
         assert_eq!(vtag.attributes.get("aria-controls"), Some(&"it-works".into()));
     } else {


### PR DESCRIPTION
Code refactored to remove enclosing `<div>`. Fragments also becomes possible #36.
This PR in progress, because components' rendering have not yet completed.

Related #107 #91 