### PR TITLE
Update to the latest stdweb (Storage, Fetch, WebSocket)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ failure = "0.1"
 http = "0.1"
 serde = "1"
 serde_json = "1"
-stdweb = "0.3"
+stdweb = "0.4"
 
 [dev-dependencies]
 serde_derive = "1"

--- a/examples/dashboard/client/Cargo.toml
+++ b/examples/dashboard/client/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 
 [dependencies]
+failure = "0.1"
 serde = "1"
 serde_derive = "1"
 yew = { path = "../../.." }

--- a/examples/dashboard/client/src/main.rs
+++ b/examples/dashboard/client/src/main.rs
@@ -1,8 +1,10 @@
+extern crate failure;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
 extern crate yew;
 
+use failure::Error;
 use yew::prelude::*;
 use yew::format::{Nothing, Json};
 use yew::services::Task;
@@ -31,8 +33,8 @@ enum WsAction {
 enum Msg {
     FetchData,
     WsAction(WsAction),
-    FetchReady(Result<DataFromFile, ()>),
-    WsReady(Result<WsResponse, ()>),
+    FetchReady(Result<DataFromFile, Error>),
+    WsReady(Result<WsResponse, Error>),
     Ignore,
 }
 
@@ -78,8 +80,9 @@ impl Component<Context> for Model {
         match msg {
             Msg::FetchData => {
                 self.fetching = true;
-                let callback = context.send_back(|response: Response<Json<Result<DataFromFile, ()>>>| {
+                let callback = context.send_back(|response: Response<Json<Result<DataFromFile, Error>>>| {
                     let (meta, Json(data)) = response.into_parts();
+                    println!("META: {:?}, {:?}", meta, data);
                     if meta.status.is_success() {
                         Msg::FetchReady(data)
                     } else {

--- a/examples/mount_point/Cargo.toml
+++ b/examples/mount_point/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["Ben Berman <ben@standardbots.com>"]
 
 [dependencies]
+stdweb = "0.4"
 yew = { path = "../.." }
-stdweb = "0.3"

--- a/examples/mount_point/src/main.rs
+++ b/examples/mount_point/src/main.rs
@@ -4,7 +4,7 @@ extern crate yew;
 extern crate stdweb;
 
 use yew::prelude::*;
-use stdweb::web::{IElement, document, INode};
+use stdweb::web::{IElement, INode, IParentNode, document};
 
 type Context = ();
 
@@ -49,10 +49,10 @@ impl Renderable<Context, Model> for Model {
 
 fn main() {
     yew::initialize();
-    let body = document().query_selector("body").unwrap();
+    let body = document().query_selector("body").unwrap().unwrap();
 
     // This canvas won't be overwritten by yew!
-    let canvas = document().create_element("canvas");
+    let canvas = document().create_element("canvas").unwrap();
     body.append_child(&canvas);
 
     js! {
@@ -65,8 +65,8 @@ fn main() {
     };
 
     let mount_class = "mount-point";
-    let mount_point = document().create_element("div");
-    mount_point.class_list().add(mount_class);
+    let mount_point = document().create_element("div").unwrap();
+    mount_point.class_list().add(mount_class).unwrap();
     body.append_child(&mount_point);
 
     let app: App<_, Model> = App::new(());

--- a/examples/npm_and_rest/Cargo.toml
+++ b/examples/npm_and_rest/Cargo.toml
@@ -4,7 +4,8 @@ version = "0.1.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 
 [dependencies]
+failure = "0.1"
 serde = "1"
 serde_derive = "1"
+stdweb = "0.4"
 yew = { path = "../.." }
-stdweb = "0.3"

--- a/examples/npm_and_rest/src/gravatar.rs
+++ b/examples/npm_and_rest/src/gravatar.rs
@@ -1,3 +1,4 @@
+use failure::Error;
 use yew::format::{Nothing, Json};
 use yew::services::fetch::{FetchService, FetchTask, Request, Response};
 use yew::html::Callback;
@@ -28,9 +29,9 @@ impl GravatarService {
         }
     }
 
-    pub fn profile(&mut self, hash: &str, callback: Callback<Result<Profile, ()>>) -> FetchTask {
+    pub fn profile(&mut self, hash: &str, callback: Callback<Result<Profile, Error>>) -> FetchTask {
         let url = format!("https://gravatar.com/{}", hash);
-        let handler = move |response: Response<Json<Result<Profile, ()>>>| {
+        let handler = move |response: Response<Json<Result<Profile, Error>>>| {
             let (_, Json(data)) = response.into_parts();
             callback.emit(data)
         };

--- a/examples/npm_and_rest/src/main.rs
+++ b/examples/npm_and_rest/src/main.rs
@@ -1,3 +1,4 @@
+extern crate failure;
 #[macro_use]
 extern crate serde_derive;
 #[macro_use]
@@ -5,6 +6,7 @@ extern crate stdweb;
 #[macro_use]
 extern crate yew;
 
+use failure::Error;
 use yew::prelude::*;
 use yew::services::fetch::FetchTask;
 
@@ -27,7 +29,7 @@ struct Model {
 
 enum Msg {
     Gravatar,
-    GravatarReady(Result<Profile, ()>),
+    GravatarReady(Result<Profile, Error>),
     Exchanges,
 }
 

--- a/examples/showcase.sh
+++ b/examples/showcase.sh
@@ -9,7 +9,8 @@ function ctrl_c() {
 
 for example in */ ; do
     cd $example
-    cargo web start --target-webasm-emscripten &
+    cargo update
+    cargo web start --target wasm32-unknown-emscripten &
     PID=$!
     wait $PID
     cd ..

--- a/examples/two_apps/Cargo.toml
+++ b/examples/two_apps/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 
 [dependencies]
-stdweb = "0.3"
+stdweb = "0.4"
 yew = { path = "../.." }

--- a/examples/two_apps/src/main.rs
+++ b/examples/two_apps/src/main.rs
@@ -6,7 +6,7 @@ extern crate yew;
 
 use std::rc::Rc;
 use std::cell::RefCell;
-use stdweb::web::document;
+use stdweb::web::{IParentNode, document};
 // Use `html` module directly. No use `App`.
 use yew::html::*;
 
@@ -67,7 +67,7 @@ impl Renderable<Context, Model> for Model {
 }
 
 fn mount_app(selector: &'static str, app: Scope<Context, Model>) {
-    let element = document().query_selector(selector).unwrap();
+    let element = document().query_selector(selector).unwrap().unwrap();
     app.mount(element);
 }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -50,17 +50,17 @@ where
     }
 }
 
-impl<T> From<Restorable> for Json<Result<T, ()>>
+impl<T> From<Restorable> for Json<Result<T, Error>>
 where
     T: for <'de> Deserialize<'de>
 {
     fn from(value: Restorable) -> Self {
         match value {
             Ok(data) => {
-                Json(serde_json::from_str(&data).map_err(drop))
+                Json(serde_json::from_str(&data).map_err(Error::from))
             }
-            Err(_reason) => {
-                Json(Err(()))
+            Err(reason) => {
+                Json(Err(reason))
             }
         }
     }

--- a/src/html.rs
+++ b/src/html.rs
@@ -463,7 +463,7 @@ macro_rules! impl_action {
 impl_action! {
     onclick(event: ClickEvent) -> MouseData => |_, event| { MouseData::from(event) }
     ondoubleclick(event: DoubleClickEvent) -> MouseData => |_, event| { MouseData::from(event) }
-    onkeypress(event: KeypressEvent) -> KeyData => |_, event| { KeyData::from(event) }
+    onkeypress(event: KeyPressEvent) -> KeyData => |_, event| { KeyData::from(event) }
     /* TODO Add PR to https://github.com/koute/stdweb
     onmousedown(event: MouseDownEvent) -> () => |_, _| { () }
     onmouseup(event: MouseUpEvent) -> () => |_, _| { () }

--- a/src/html.rs
+++ b/src/html.rs
@@ -8,7 +8,7 @@ use std::cell::{RefCell, RefMut};
 use std::ops::{Deref, DerefMut};
 use std::sync::mpsc::{Sender, Receiver, channel};
 use stdweb::Value;
-use stdweb::web::{Element, INode, Node, EventListenerHandle, document};
+use stdweb::web::{Element, INode, Node, EventListenerHandle, IParentNode, document};
 use stdweb::web::event::{IMouseEvent, IKeyboardEvent, BlurEvent};
 use virtual_dom::{VDiff, VNode, Listener};
 
@@ -307,7 +307,8 @@ where
     /// Alias to `mount("body", ...)`.
     pub fn mount_to_body(self) {
         let element = document().query_selector("body")
-            .expect("can't get body node for rendering");
+            .expect("can't get body node for rendering")
+            .expect("can't unwrap body node");
         self.mount(element)
     }
 
@@ -480,7 +481,7 @@ impl_action! {
         use stdweb::web::html_element::InputElement;
         use stdweb::unstable::TryInto;
         let input: InputElement = this.clone().try_into().expect("only an InputElement can have an oninput event listener");
-        let value = input.value().into_string().unwrap_or_else(|| "".into());
+        let value = input.raw_value();
         InputData { value }
     }
 }
@@ -492,22 +493,22 @@ pub struct MouseData {
     /// [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/screenX)
     /// property which provides the horizontal coordinate (offset)
     /// of the mouse pointer in global (screen) coordinates.
-    pub screen_x: f64,
+    pub screen_x: i32,
     /// The screenY is a read-only property of the
     /// [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/screenY)
     /// property which provides the vertical coordinate (offset)
     /// of the mouse pointer in global (screen) coordinates.
-    pub screen_y: f64,
+    pub screen_y: i32,
     /// The clientX is a read-only property of the
     /// [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientX)
     /// interface which provides the horizontal coordinate within
     /// the application's client area at which the event occurred
-    pub client_x: f64,
+    pub client_x: i32,
     /// The clientY is a read-only property of the
     /// [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientX)
     /// interface which provides the vertical coordinate within
     /// the application's client area at which the event occurred
-    pub client_y: f64,
+    pub client_y: i32,
 }
 
 impl<T: IMouseEvent> From<T> for MouseData {

--- a/src/services/storage.rs
+++ b/src/services/storage.rs
@@ -43,7 +43,8 @@ impl StorageService {
         T: Into<Storable>
     {
         if let Some(data) = value.into() {
-            self.storage.insert(key, &data);
+            self.storage.insert(key, &data)
+                .expect("can't insert value to a storage");
         }
     }
 

--- a/src/services/storage.rs
+++ b/src/services/storage.rs
@@ -1,7 +1,7 @@
 //! This module contains the implementation of a service to
 //! use local and session storage of a browser.
 
-use stdweb::Value;
+use stdweb::web::{window, Storage};
 use format::{Storable, Restorable};
 
 /// Represents errors of a storage.
@@ -21,14 +21,20 @@ pub enum Area {
 
 /// A storage service attached to a context.
 pub struct StorageService {
-    scope: Area,
+    storage: Storage,
 }
 
 impl StorageService {
 
-    /// Creates a new storage service instance with specified storate scope.
-    pub fn new(scope: Area) -> Self {
-        StorageService { scope }
+    /// Creates a new storage service instance with specified storate area.
+    pub fn new(area: Area) -> Self {
+        let storage = {
+            match area {
+                Area::Local => window().local_storage(),
+                Area::Session => window().session_storage(),
+            }
+        };
+        StorageService { storage }
     }
 
     /// Stores value to the storage.
@@ -37,14 +43,7 @@ impl StorageService {
         T: Into<Storable>
     {
         if let Some(data) = value.into() {
-            match self.scope {
-                Area::Local => { js! { @(no_return)
-                    localStorage.setItem(@{key}, @{data});
-                } },
-                Area::Session => { js! { @(no_return)
-                    sessionStorage.setItem(@{key}, @{data});
-                } },
-            }
+            self.storage.insert(key, &data);
         }
     }
 
@@ -53,27 +52,13 @@ impl StorageService {
     where
         T : From<Restorable>
     {
-        let value: Value = {
-            match self.scope {
-                Area::Local => js! { return localStorage.getItem(@{key}); },
-                Area::Session => js! { return sessionStorage.getItem(@{key}); },
-            }
-        };
-        let data = value.into_string().ok_or_else(|| StorageError::CantRestore.into());
+        let data = self.storage.get(key)
+            .ok_or_else(|| StorageError::CantRestore.into());
         T::from(data)
     }
 
     /// Removes value from the storage.
     pub fn remove(&mut self, key: &str) {
-        {
-            match self.scope {
-                Area::Local => js! { @(no_return)
-                    localStorage.removeItem(@{key});
-                },
-                Area::Session => js! { @(no_return)
-                    sessionStorage.removeItem(@{key});
-                },
-            }
-        };
+        self.storage.remove(key);
     }
 }

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -12,7 +12,6 @@ use super::{Reform, VDiff, VNode};
 struct Hidden;
 
 type AnyProps = (TypeId, *mut Hidden);
-type HandleCell = Rc<RefCell<Option<ScopeHandle>>>;
 
 /// A virtual component.
 pub struct VComp<CTX, COMP: Component<CTX>> {

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -257,7 +257,8 @@ where
                 // There is created an empty text node to be replaced with mount call.
                 let node = node.map(|sibling| {
                     let element = document().create_text_node("");
-                    parent.insert_before(&element, &sibling);
+                    parent.insert_before(&element, &sibling)
+                        .expect("can't insert dummy element for a component");
                     element.as_node().to_owned()
                 });
                 self.mount(env.context(), parent, node, any_props);

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -253,11 +253,13 @@ impl<CTX: 'static, COMP: Component<CTX>> VDiff for VTag<CTX, COMP> {
             Reform::Before(node) => {
                 let element = document().create_element(&self.tag);
                 if let Some(sibling) = node {
-                    parent.insert_before(&element, &sibling);
+                    parent.insert_before(&element, &sibling)
+                        .expect("can't insert tag before sibling");
                 } else {
                     let precursor = precursor.and_then(|node| node.next_sibling());
                     if let Some(precursor) = precursor {
-                        parent.insert_before(&element, &precursor);
+                        parent.insert_before(&element, &precursor)
+                            .expect("can't insert tag before precursor");
                     } else {
                         parent.append_child(&element);
                     }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -251,7 +251,8 @@ impl<CTX: 'static, COMP: Component<CTX>> VDiff for VTag<CTX, COMP> {
             Reform::Keep => {
             }
             Reform::Before(node) => {
-                let element = document().create_element(&self.tag);
+                let element = document().create_element(&self.tag)
+                    .expect("can't create element for vtag");
                 if let Some(sibling) = node {
                     parent.insert_before(&element, &sibling)
                         .expect("can't insert tag before sibling");
@@ -287,10 +288,12 @@ impl<CTX: 'static, COMP: Component<CTX>> VDiff for VTag<CTX, COMP> {
                 match change {
                     Patch::Add(class, _) |
                     Patch::Replace(class, _) => {
-                        list.add(&class);
+                        list.add(&class)
+                            .expect("can't add a class");
                     }
                     Patch::Remove(class) => {
-                        list.remove(&class);
+                        list.remove(&class)
+                            .expect("can't remove a class");
                     }
                 }
             }
@@ -317,10 +320,19 @@ impl<CTX: 'static, COMP: Component<CTX>> VDiff for VTag<CTX, COMP> {
                     match change {
                         Patch::Add(kind, _) |
                         Patch::Replace(kind, _) => {
-                            input.set_kind(&kind);
+                            //https://github.com/koute/stdweb/commit/3b85c941db00b8e3c942624afd50c5929085fb08
+                            //input.set_kind(&kind);
+                            let input = &input;
+                            js! { @(no_return)
+                                @{input}.type = @{kind};
+                            }
                         }
                         Patch::Remove(_) => {
-                            input.set_kind("");
+                            //input.set_kind("");
+                            let input = &input;
+                            js! { @(no_return)
+                                @{input}.type = "";
+                            }
                         }
                     }
                 }
@@ -329,10 +341,10 @@ impl<CTX: 'static, COMP: Component<CTX>> VDiff for VTag<CTX, COMP> {
                     match change {
                         Patch::Add(kind, _) |
                         Patch::Replace(kind, _) => {
-                            input.set_value(&kind);
+                            input.set_raw_value(&kind);
                         }
                         Patch::Remove(_) => {
-                            input.set_value("");
+                            input.set_raw_value("");
                         }
                     }
                 }

--- a/src/virtual_dom/vtext.rs
+++ b/src/virtual_dom/vtext.rs
@@ -82,7 +82,8 @@ impl<CTX: 'static, COMP: Component<CTX>> VDiff for VText<CTX, COMP> {
             Reform::Before(node) => {
                 let element = document().create_text_node(&self.text);
                 if let Some(sibling) = node {
-                    parent.insert_before(&element, &sibling);
+                    parent.insert_before(&element, &sibling)
+                        .expect("can't insert text before sibling");
                 } else {
                     parent.append_child(&element);
                 }


### PR DESCRIPTION
Move to the latest `stdweb` features:

- [x] Refactoring/renaming
- [x] Use `Storage`
- [ ] ~Use XmlHttpRequest~
- [ ] ~Use WebSocket~

UPD: It's better to rewrite `XmlHttpRequest` and `WebSocket` in another PRs, because they are quite large and API little different.