### PR TITLE
Use opposite element to replace instead of sibling

### DIFF
--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -222,8 +222,7 @@ where
                 self.mount(env.context(), parent, node);
             }
         }
-        // TODO Fix: self.get_node()
-        None
+        self.cell.borrow().as_ref().map(|node| node.to_owned())
     }
 }
 

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::marker::PhantomData;
 use std::any::TypeId;
-use stdweb::web::{INode, Node, Element};
+use stdweb::web::{INode, Node, Element, document};
 use html::{ScopeBuilder, SharedContext, Component, Renderable, ComponentUpdate, ScopeSender, Callback, ScopeEnv, NodeCell};
 use stdweb::unstable::TryInto;
 use super::{Reform, VDiff, VNode};
@@ -219,6 +219,14 @@ where
             Reform::Keep => {
             }
             Reform::Before(node) => {
+                // This is a workaround, because component should be mounted
+                // over opposite element if it exists.
+                // There is created an empty text node to be replaced with mount call.
+                let node = node.map(|sibling| {
+                    let element = document().create_text_node("");
+                    parent.insert_before(&element, &sibling);
+                    element.as_node().to_owned()
+                });
                 self.mount(env.context(), parent, node);
             }
         }

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -20,7 +20,6 @@ pub enum VNode<CTX, COMP: Component<CTX>> {
     VRef(Node),
 }
 
-
 impl<CTX: 'static, COMP: Component<CTX>> VDiff for VNode<CTX, COMP> {
     type Context = CTX;
     type Component = COMP;


### PR DESCRIPTION
Fixes bug when footer disappeared when it placed after component.