### PR TITLE
Set properties on component creation

### DIFF
--- a/examples/counter/src/main.rs
+++ b/examples/counter/src/main.rs
@@ -24,7 +24,7 @@ impl Component<Context> for Model {
     type Msg = Msg;
     type Properties = ();
 
-    fn create(_: &mut Env<Context, Self>) -> Self {
+    fn create(_: Self::Properties, _: &mut Env<Context, Self>) -> Self {
         Model {
             value: 0,
         }

--- a/examples/crm/src/main.rs
+++ b/examples/crm/src/main.rs
@@ -60,7 +60,7 @@ impl Component<Context> for Model {
     type Msg = Msg;
     type Properties = ();
 
-    fn create(context: &mut Env<Context, Self>) -> Self {
+    fn create(_: Self::Properties, context: &mut Env<Context, Self>) -> Self {
         let Json(database) = context.storage.restore(KEY);
         let database = database.unwrap_or_else(|_| Database {
             clients: Vec::new(),

--- a/examples/custom_components/src/barrier.rs
+++ b/examples/custom_components/src/barrier.rs
@@ -31,11 +31,11 @@ impl<CTX: 'static> Component<CTX> for Barrier {
     type Msg = Msg;
     type Properties = Props;
 
-    fn create(_: &mut Env<CTX, Self>) -> Self {
+    fn create(props: Self::Properties, _: &mut Env<CTX, Self>) -> Self {
         Barrier {
-            limit: 0,
+            limit: props.limit,
             counter: 0,
-            onsignal: None,
+            onsignal: props.onsignal,
         }
     }
 

--- a/examples/custom_components/src/button.rs
+++ b/examples/custom_components/src/button.rs
@@ -28,10 +28,10 @@ impl<CTX: 'static> Component<CTX> for Button {
     type Msg = Msg;
     type Properties = Props;
 
-    fn create(_: &mut Env<CTX, Self>) -> Self {
+    fn create(props: Self::Properties, _: &mut Env<CTX, Self>) -> Self {
         Button {
-            title: "Send Signal".into(),
-            onsignal: None,
+            title: props.title,
+            onsignal: props.onsignal,
         }
     }
 

--- a/examples/custom_components/src/counter.rs
+++ b/examples/custom_components/src/counter.rs
@@ -38,11 +38,11 @@ impl<CTX: Printer + 'static> Component<CTX> for Counter {
     type Msg = Msg;
     type Properties = Props;
 
-    fn create(_: &mut Env<CTX, Self>) -> Self {
+    fn create(props: Self::Properties, _: &mut Env<CTX, Self>) -> Self {
         Counter {
-            value: 0,
-            color: Color::Green,
-            onclick: None,
+            value: props.initial,
+            color: props.color,
+            onclick: props.onclick,
         }
     }
 
@@ -60,9 +60,6 @@ impl<CTX: Printer + 'static> Component<CTX> for Counter {
     }
 
     fn change(&mut self, props: Self::Properties, _: &mut Env<CTX, Self>) -> ShouldRender {
-        if self.value == 0 {
-            self.value = props.initial;
-        }
         self.color = props.color;
         self.onclick = props.onclick;
         true

--- a/examples/custom_components/src/main.rs
+++ b/examples/custom_components/src/main.rs
@@ -37,7 +37,7 @@ impl Component<Context> for Model {
     type Msg = Msg;
     type Properties = ();
 
-    fn create(_: &mut Env<Context, Self>) -> Self {
+    fn create(_: Self::Properties, _: &mut Env<Context, Self>) -> Self {
         Model {
             with_barrier: false,
             color: Color::Red,

--- a/examples/dashboard/client/src/main.rs
+++ b/examples/dashboard/client/src/main.rs
@@ -64,7 +64,7 @@ impl Component<Context> for Model {
     type Msg = Msg;
     type Properties = ();
 
-    fn create(_: &mut Env<Context, Self>) -> Self {
+    fn create(_: Self::Properties, _: &mut Env<Context, Self>) -> Self {
         Model {
             fetching: false,
             data: None,

--- a/examples/fragments/src/main.rs
+++ b/examples/fragments/src/main.rs
@@ -18,7 +18,7 @@ impl Component<Context> for Model {
     type Msg = Msg;
     type Properties = ();
 
-    fn create(_: &mut Env<Context, Self>) -> Self {
+    fn create(_: Self::Properties, _: &mut Env<Context, Self>) -> Self {
         Model {
             counter: 0,
         }

--- a/examples/game_of_life/src/main.rs
+++ b/examples/game_of_life/src/main.rs
@@ -149,7 +149,7 @@ impl Component<Context> for GameOfLife {
     type Msg = Msg;
     type Properties = ();
 
-    fn create(_: &mut Env<Context, Self>) -> Self {
+    fn create(_: Self::Properties, _: &mut Env<Context, Self>) -> Self {
         GameOfLife {
             cellules: vec![Cellule { life_state: LifeState::Dead }; 2000],
             cellules_width: 50,

--- a/examples/mount_point/src/main.rs
+++ b/examples/mount_point/src/main.rs
@@ -20,7 +20,7 @@ impl Component<Context> for Model {
     type Msg = Msg;
     type Properties = ();
 
-    fn create(_: &mut Env<Context, Self>) -> Self {
+    fn create(_: Self::Properties, _: &mut Env<Context, Self>) -> Self {
         Model {
             name: "Reversed".to_owned(),
         }

--- a/examples/npm_and_rest/src/main.rs
+++ b/examples/npm_and_rest/src/main.rs
@@ -33,7 +33,7 @@ impl Component<Context> for Model {
     type Msg = Msg;
     type Properties = ();
 
-    fn create(_: &mut Env<Context, Self>) -> Self {
+    fn create(_: Self::Properties, _: &mut Env<Context, Self>) -> Self {
         Model {
             profile: None,
             exchanges: Vec::new(),

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -31,7 +31,7 @@ impl Component<Context> for Model {
     type Msg = Msg;
     type Properties = ();
 
-    fn create(_: &mut Env<Context, Self>) -> Self {
+    fn create(_: Self::Properties, _: &mut Env<Context, Self>) -> Self {
         Model {
             job: None,
             messages: Vec::new(),

--- a/examples/todomvc/src/main.rs
+++ b/examples/todomvc/src/main.rs
@@ -52,7 +52,7 @@ impl Component<Context> for Model {
     type Msg = Msg;
     type Properties = ();
 
-    fn create(context: &mut Env<Context, Self>) -> Self {
+    fn create(_: Self::Properties, context: &mut Env<Context, Self>) -> Self {
         let entries = {
             if let Json(Ok(restored_model)) = context.storage.restore(KEY) {
                 restored_model

--- a/examples/two_apps/src/main.rs
+++ b/examples/two_apps/src/main.rs
@@ -29,10 +29,10 @@ impl Component<Context> for Model {
     type Msg = Msg;
     type Properties = ();
 
-    fn create(context: &mut Env<Context, Self>) -> Self {
+    fn create(_: Self::Properties, context: &mut Env<Context, Self>) -> Self {
         let sender = context.senders.pop().unwrap();
         Model {
-            // TODO Need properties here...
+            // TODO Use properties to set sender...
             sender,
             selector: "",
             title: "Nothing".into(),

--- a/src/html.rs
+++ b/src/html.rs
@@ -25,7 +25,7 @@ pub trait Component<CTX>: Sized + 'static {
     /// with unknown type.
     type Properties: Clone + PartialEq + Default;
     /// Initialization routine which could use a context.
-    fn create(context: &mut Env<CTX, Self>) -> Self;
+    fn create(props: Self::Properties, context: &mut Env<CTX, Self>) -> Self;
     /// Called everytime when a messages of `Msg` type received. It also takes a
     /// reference to a context.
     fn update(&mut self, msg: Self::Msg, context: &mut Env<CTX, Self>) -> ShouldRender;
@@ -290,16 +290,17 @@ where
     /// will render the model to a virtual DOM tree.
     pub fn mount(self, element: Element) {
         clear_element(&element);
-        self.mount_in_place(element, None, None);
+        self.mount_in_place(element, None, None, None);
     }
 
     // TODO Consider to use &Node instead of Element as parent
     /// Mounts elements in place of previous node.
-    pub fn mount_in_place(mut self, element: Element, obsolete: Option<VNode<CTX, COMP>>, mut occupied: Option<NodeCell>) {
+    pub fn mount_in_place(mut self, element: Element, obsolete: Option<VNode<CTX, COMP>>, mut occupied: Option<NodeCell>, init_props: Option<COMP::Properties>) {
         let mut component = {
+            let props = init_props.unwrap_or_default();
             let mut env = self.get_env();
             let mut scope_ref = env.get_ref();
-            COMP::create(&mut scope_ref)
+            COMP::create(props, &mut scope_ref)
         };
         // No messages at start
         let mut updates = Vec::new();


### PR DESCRIPTION
1) Fixes bug with initial value in `custom_components` example
2) Improves initialization performance, because it doesn't need to call component's loop after initialization to set properties
