### PR TITLE
Add ScopeHandle for component destroying

### DIFF
--- a/examples/npm_and_rest/src/gravatar.rs
+++ b/examples/npm_and_rest/src/gravatar.rs
@@ -1,5 +1,5 @@
 use yew::format::{Nothing, Json};
-use yew::services::fetch::{FetchService, FetchHandle, Request, Response};
+use yew::services::fetch::{FetchService, FetchTask, Request, Response};
 use yew::html::Callback;
 
 #[derive(Deserialize, Debug)]
@@ -28,7 +28,7 @@ impl GravatarService {
         }
     }
 
-    pub fn profile(&mut self, hash: &str, callback: Callback<Result<Profile, ()>>) -> FetchHandle {
+    pub fn profile(&mut self, hash: &str, callback: Callback<Result<Profile, ()>>) -> FetchTask {
         let url = format!("https://gravatar.com/{}", hash);
         let handler = move |response: Response<Json<Result<Profile, ()>>>| {
             let (_, Json(data)) = response.into_parts();

--- a/examples/npm_and_rest/src/main.rs
+++ b/examples/npm_and_rest/src/main.rs
@@ -6,6 +6,7 @@ extern crate stdweb;
 extern crate yew;
 
 use yew::prelude::*;
+use yew::services::fetch::FetchTask;
 
 // Own services implementation
 mod gravatar;
@@ -21,6 +22,7 @@ struct Context {
 struct Model {
     profile: Option<Profile>,
     exchanges: Vec<String>,
+    task: Option<FetchTask>,
 }
 
 enum Msg {
@@ -37,6 +39,7 @@ impl Component<Context> for Model {
         Model {
             profile: None,
             exchanges: Vec::new(),
+            task: None,
         }
     }
 
@@ -44,7 +47,8 @@ impl Component<Context> for Model {
         match msg {
             Msg::Gravatar => {
                 let callback = context.send_back(Msg::GravatarReady);
-                context.gravatar.profile("205e460b479e2e5b48aec07710c08d50", callback);
+                let task = context.gravatar.profile("205e460b479e2e5b48aec07710c08d50", callback);
+                self.task = Some(task);
             }
             Msg::GravatarReady(Ok(profile)) => {
                 self.profile = Some(profile);

--- a/src/html.rs
+++ b/src/html.rs
@@ -237,6 +237,13 @@ impl<CTX, COMP: Component<CTX>> ScopeBuilder<CTX, COMP> {
         }
     }
 
+    /// Return handler to a scope. Warning! Don't use more than one handle!
+    pub fn handle(&self) -> ScopeHandle {
+        ScopeHandle {
+            bind: self.bind.clone(),
+        }
+    }
+
     pub fn build(self, context: SharedContext<CTX>) -> Scope<CTX, COMP> {
         Scope {
             tx: self.tx,
@@ -294,7 +301,7 @@ where
     COMP: Component<CTX> + Renderable<CTX, COMP>,
 {
     /// Alias to `mount("body", ...)`.
-    pub fn mount_to_body(self) -> ScopeHandle {
+    pub fn mount_to_body(self) {
         let element = document().query_selector("body")
             .expect("can't get body node for rendering");
         self.mount(element)
@@ -304,14 +311,14 @@ where
     /// function in Elm. You should provide an initial model, `update` function
     /// which will update the state of the model and a `view` function which
     /// will render the model to a virtual DOM tree.
-    pub fn mount(self, element: Element) -> ScopeHandle {
+    pub fn mount(self, element: Element) {
         clear_element(&element);
         self.mount_in_place(element, None, None, None)
     }
 
     // TODO Consider to use &Node instead of Element as parent
     /// Mounts elements in place of previous node.
-    pub fn mount_in_place(mut self, element: Element, obsolete: Option<VNode<CTX, COMP>>, mut occupied: Option<NodeCell>, init_props: Option<COMP::Properties>) -> ScopeHandle {
+    pub fn mount_in_place(mut self, element: Element, obsolete: Option<VNode<CTX, COMP>>, mut occupied: Option<NodeCell>, init_props: Option<COMP::Properties>) {
         let mut component = {
             let props = init_props.unwrap_or_default();
             let mut env = self.get_env();
@@ -358,15 +365,11 @@ where
         };
         // Initial call for first rendering
         callback();
-        let handle = ScopeHandle {
-            bind: bind.clone(),
-        };
         js! { @(no_return)
             var bind = @{bind};
             var callback = @{callback};
             bind.loop = callback;
         }
-        handle
     }
 }
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -211,7 +211,8 @@ impl<CTX, COMP: Component<CTX>> ScopeSender<CTX, COMP> {
                 window._yew_schedule_(bind);
             }
         } else {
-            eprintln!("app lost the receiver!");
+            eprintln!("Can't send message to a component. Receiver lost! \
+                       Maybe Task lives longer than a component instance.");
         }
     }
 }

--- a/src/services/interval.rs
+++ b/src/services/interval.rs
@@ -43,6 +43,14 @@ impl IntervalService {
     }
 }
 
+impl Drop for IntervalHandle {
+    fn drop(&mut self) {
+        if self.0.is_some() {
+            self.cancel();
+        }
+    }
+}
+
 impl Task for IntervalHandle {
     fn cancel(&mut self) {
         let handle = self.0.take().expect("tried to cancel interval twice");

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -13,8 +13,11 @@ pub mod websocket;
 
 use std::time::Duration;
 
-/// An universal interface to service's routine. At least could be canceled.
-pub trait Task {
+/// An universal task of a service.
+/// It have to be canceled when dropped.
+pub trait Task: Drop {
+    /// Returns `true` if task is active.
+    fn is_active(&self) -> bool;
     /// Cancel current service's routine.
     fn cancel(&mut self);
 }

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -102,7 +102,7 @@ impl<CTX: 'static, COMP: Component<CTX>> VComp<CTX, COMP> {
     }
 
     /// This methods gives sender from older node.
-    pub(crate) fn grab_sender_of(&mut self, mut other: Self) {
+    pub(crate) fn grab_sender_of(&mut self, other: Self) {
         assert_eq!(self.type_id, other.type_id);
         // Grab a sender and a cell (element's reference) to reuse it later
         self.blind_sender = other.blind_sender;

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -49,8 +49,10 @@ impl<CTX: 'static, COMP: Component<CTX>> VComp<CTX, COMP> {
 
             let builder = builder.take().expect("tried to mount component twice");
             let opposite = obsolete.map(VNode::VRef);
+            let handle = builder.handle();
             builder.build(context)
-                .mount_in_place(element, opposite, Some(occupied.clone()), Some(props))
+                .mount_in_place(element, opposite, Some(occupied.clone()), Some(props));
+            handle
         };
         let mut previous_props = None;
         let blind_sender = move |(type_id, raw): AnyProps| {

--- a/tests/vlist_test.rs
+++ b/tests/vlist_test.rs
@@ -13,7 +13,7 @@ impl Component<Ctx> for Comp {
     type Msg = ();
     type Properties = ();
 
-    fn create(_: &mut Env<Ctx, Self>) -> Self {
+    fn create(_: Self::Properties, _: &mut Env<Ctx, Self>) -> Self {
         Comp
     }
 

--- a/tests/vtag_test.rs
+++ b/tests/vtag_test.rs
@@ -12,7 +12,7 @@ impl Component<Ctx> for Comp {
     type Msg = ();
     type Properties = ();
 
-    fn create(_: &mut Env<Ctx, Self>) -> Self {
+    fn create(_: Self::Properties, _: &mut Env<Ctx, Self>) -> Self {
         Comp
     }
 


### PR DESCRIPTION
This is experimental PR aimed to fix memory leaks with component replacement.
`mount_*` methods returns a handle which could be moved to a builder. Work in progress.