### PR TITLE
Improve game_of_life example

### DIFF
--- a/examples/game_of_life/Cargo.toml
+++ b/examples/game_of_life/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "game_of_life"
-version = "0.1.0"
-authors = ["Diego Cardoso <dige0card0s0@hotmail.com>"]
+version = "0.1.1"
+authors = ["Diego Cardoso <dige0card0s0@hotmail.com>",
+           "Ilya Bogdanov <fumlead@gmail.com"]
 
 [dependencies]
 yew = { path = "../.." }


### PR DESCRIPTION
Hi, @DenisKolodin, long time no see.

Being a gamedev-oriented Rust developer (yes, I invented it myself :D), I couldn't miss such a cutie example of famous Game of Life. Thanks @diegocardoso93!

I've made some improvements:
- Rewrote some things in a more "Rustish" way (like using iterators instead of loop in `count_live_neighbor`
- Fixed some grammar and spelling. I'm not native though, so tell me if I'm mistaken
- Fixed logic, including wrapping game grid around imaginary torus (now grid is like torus' surface, not restricted plane)
- Improved performance (I think) by using static arrays and reducing the number of allocations.
- Refactored code a bit in order to make it more readable.