### PR TITLE
Remove ES6 syntax in WebSocketService::connect

### DIFF
--- a/src/services/websocket.rs
+++ b/src/services/websocket.rs
@@ -65,9 +65,7 @@ impl WebSocketService {
             socket.onmessage = function(event) {
                 callback(event.data);
             };
-            return {
-                socket,
-            };
+            return { socket: socket };
         };
         WebSocketTask(Some(handle))
     }


### PR DESCRIPTION
Use of ES6 syntax breaks compilation in Emscripten release mode.