### PR TITLE
Use panic instead of ignoring in change method of Component

### DIFF
--- a/examples/showcase.sh
+++ b/examples/showcase.sh
@@ -1,5 +1,3 @@
-trap ctrl_c INT
-
 PID=-1
 
 function ctrl_c() {
@@ -10,6 +8,14 @@ function ctrl_c() {
 for example in */ ; do
     cd $example
     cargo update
+    cargo web build --target wasm32-unknown-emscripten
+    cd ..
+done
+
+trap ctrl_c INT
+
+for example in */ ; do
+    cd $example
     cargo web start --target wasm32-unknown-emscripten &
     PID=$!
     wait $PID

--- a/src/html.rs
+++ b/src/html.rs
@@ -30,7 +30,9 @@ pub trait Component<CTX>: Sized + 'static {
     /// reference to a context.
     fn update(&mut self, msg: Self::Msg, context: &mut Env<CTX, Self>) -> ShouldRender;
     /// This method called when properties changes, and once when component created.
-    fn change(&mut self, _: Self::Properties, _: &mut Env<CTX, Self>) -> ShouldRender { false }
+    fn change(&mut self, _: Self::Properties, _: &mut Env<CTX, Self>) -> ShouldRender {
+        unimplemented!("you should implement `change` method for a component with properties")
+    }
 }
 
 /// Should be rendered relative to context and component environment.


### PR DESCRIPTION
Fixes usability issue #172
Method `change` panics if developer sets properties, but ignores it

Extra: Build all examples before start any in showcase script
