### PR TITLE
Fix most of the clippy warnings

### DIFF
--- a/src/html.rs
+++ b/src/html.rs
@@ -173,7 +173,7 @@ impl<CTX, COMP: Component<CTX>> ScopeEnv<CTX, COMP> {
 
 impl<CTX: 'static, COMP: Component<CTX>> ScopeEnv<CTX, COMP> {
     /// Returns reference to a scope data.
-    pub fn get_ref<'a>(&'a mut self) -> Env<'a, CTX, COMP> {
+    pub fn get_ref(&mut self) -> Env<CTX, COMP> {
         Env {
             context: self.context.borrow_mut(),
             sender: &mut self.sender,
@@ -255,7 +255,7 @@ impl<CTX, COMP: Component<CTX>> ScopeBuilder<CTX, COMP> {
         Scope {
             tx: self.tx,
             rx: Some(self.rx),
-            context: context,
+            context,
             bind: self.bind,
         }
     }
@@ -342,7 +342,7 @@ where
         };
         // No messages at start
         let mut updates = Vec::new();
-        let mut last_frame = VNode::from(component.view());
+        let mut last_frame = component.view();
         // First-time rendering the tree
         let node = last_frame.apply(element.as_node(), None, obsolete, self.get_env());
         if let Some(ref mut cell) = occupied {
@@ -371,7 +371,7 @@ where
                 }
             }
             if should_update {
-                let mut next_frame = VNode::from(component.view());
+                let mut next_frame = component.view();
                 // Re-rendering the tree
                 let node =
                     next_frame.apply(element.as_node(), None, last_frame.take(), self.get_env());
@@ -487,7 +487,6 @@ impl_action! {
     onmouseout(event: MouseOutEvent) -> () => |_, _| { () }
     */
     onblur(event: BlurEvent) -> BlurData => |_, event| {
-        let event = BlurEvent::from(event);
         BlurData::from(event)
     }
     oninput(event: InputEvent) -> InputData => |this: &Element, _| {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -181,7 +181,7 @@ pub fn set_value<CTX, COMP: Component<CTX>, T: ToString>(stack: &mut Stack<CTX, 
 #[doc(hidden)]
 pub fn set_kind<CTX, COMP: Component<CTX>, T: ToString>(stack: &mut Stack<CTX, COMP>, value: T) {
     if let Some(&mut VNode::VTag(ref mut vtag)) = stack.last_mut() {
-        vtag.set_kind(value);
+        vtag.set_kind(&value);
     } else {
         panic!("no tag to set type: {}", value.to_string());
     }
@@ -203,7 +203,7 @@ pub fn add_attribute<CTX, COMP: Component<CTX>, T: ToString>(
     value: T,
 ) {
     if let Some(&mut VNode::VTag(ref mut vtag)) = stack.last_mut() {
-        vtag.add_attribute(name, value);
+        vtag.add_attribute(name, &value);
     } else {
         panic!("no tag to set attribute: {}", name);
     }

--- a/src/services/fetch.rs
+++ b/src/services/fetch.rs
@@ -22,6 +22,7 @@ enum FetchError {
 pub struct FetchTask(Option<Value>);
 
 /// A service to fetch resources.
+#[derive(Default)]
 pub struct FetchService {}
 
 impl FetchService {
@@ -130,7 +131,7 @@ impl FetchService {
                     map[key] = value;
                 });
                 return map;
-            }).unwrap_or(HashMap::new());
+            }).unwrap_or_default();
 
             for (key, values) in &headers {
                 response_builder.header(key.as_str(), values.as_str());

--- a/src/services/interval.rs
+++ b/src/services/interval.rs
@@ -11,6 +11,7 @@ use stdweb::Value;
 pub struct IntervalTask(Option<Value>);
 
 /// A service to send messages on every elapsed interval.
+#[derive(Default)]
 pub struct IntervalService {}
 
 impl IntervalService {

--- a/src/services/timeout.rs
+++ b/src/services/timeout.rs
@@ -10,6 +10,7 @@ use stdweb::Value;
 pub struct TimeoutTask(Option<Value>);
 
 /// An service to set a timeout.
+#[derive(Default)]
 pub struct TimeoutService {}
 
 impl TimeoutService {

--- a/src/services/websocket.rs
+++ b/src/services/websocket.rs
@@ -1,5 +1,5 @@
 //! Service to connect to a servers by
-//! [WebSocket Protocol](https://tools.ietf.org/html/rfc6455).
+//! [`WebSocket` Protocol](https://tools.ietf.org/html/rfc6455).
 
 use super::Task;
 use format::{Restorable, Storable};
@@ -18,6 +18,7 @@ pub enum WebSocketStatus {
 pub struct WebSocketTask(Option<Value>);
 
 /// A websocket service attached to a user context.
+#[derive(Default)]
 pub struct WebSocketService {}
 
 impl WebSocketService {

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -101,12 +101,12 @@ impl<'a, CTX, COMP: Component<CTX>> From<&'a Renderable<CTX, COMP>> for VNode<CT
 
 impl<CTX, COMP: Component<CTX>> fmt::Debug for VNode<CTX, COMP> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            &VNode::VTag(ref vtag) => vtag.fmt(f),
-            &VNode::VText(ref vtext) => vtext.fmt(f),
-            &VNode::VComp(_) => "Component<>".fmt(f),
-            &VNode::VList(_) => "List<>".fmt(f),
-            &VNode::VRef(_) => "NodeReference<>".fmt(f),
+        match *self {
+            VNode::VTag(ref vtag) => vtag.fmt(f),
+            VNode::VText(ref vtext) => vtext.fmt(f),
+            VNode::VComp(_) => "Component<>".fmt(f),
+            VNode::VList(_) => "List<>".fmt(f),
+            VNode::VRef(_) => "NodeReference<>".fmt(f),
         }
     }
 }
@@ -122,15 +122,7 @@ impl<CTX, COMP: Component<CTX>> PartialEq for VNode<CTX, COMP> {
                 VNode::VText(ref vtext_b) => vtext_a == vtext_b,
                 _ => false,
             },
-            VNode::VComp(_) => {
-                // TODO Implement it
-                false
-            }
-            VNode::VList(_) => {
-                // TODO Implement it
-                false
-            }
-            VNode::VRef(_) => {
+            _ => {
                 // TODO Implement it
                 false
             }

--- a/src/virtual_dom/vtext.rs
+++ b/src/virtual_dom/vtext.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 use stdweb::web::{document, INode, Node, TextNode};
 
 /// A type for a virtual
-/// [TextNode](https://developer.mozilla.org/en-US/docs/Web/API/Document/createTextNode)
+/// [`TextNode`](https://developer.mozilla.org/en-US/docs/Web/API/Document/createTextNode)
 /// represenation.
 pub struct VText<CTX, COMP: Component<CTX>> {
     /// Contains a text of the node.
@@ -40,7 +40,7 @@ impl<CTX: 'static, COMP: Component<CTX>> VDiff for VText<CTX, COMP> {
         let node = self.reference
             .expect("tried to remove not rendered VText from DOM");
         let sibling = node.next_sibling();
-        if let Err(_) = parent.remove_child(&node) {
+        if parent.remove_child(&node).is_err() {
             warn!("Node not found to remove VText");
         }
         sibling
@@ -102,6 +102,6 @@ impl<CTX, COMP: Component<CTX>> fmt::Debug for VText<CTX, COMP> {
 
 impl<CTX, COMP: Component<CTX>> PartialEq for VText<CTX, COMP> {
     fn eq(&self, other: &VText<CTX, COMP>) -> bool {
-        return self.text == other.text;
+        self.text == other.text
     }
 }


### PR DESCRIPTION
Some warnings haven't fixed because it breaks `html!` macro