### PR TITLE
Add Routing Service (dual!)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ http = "0.1"
 serde = "1"
 serde_json = "1"
 stdweb = "0.4"
+url = "1.7.0"
 
 [dev-dependencies]
 serde_derive = "1"

--- a/examples/counter_router/Cargo.toml
+++ b/examples/counter_router/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "counter_router"
+version = "0.1.0"
+authors = ["Garrett Berg <vitiral@gmail.com>"]
+
+[dependencies]
+stdweb = "0.4.2"
+yew = {path="../../"}

--- a/examples/counter_router/src/main.rs
+++ b/examples/counter_router/src/main.rs
@@ -1,0 +1,106 @@
+#[macro_use]
+extern crate stdweb;
+#[macro_use]
+extern crate yew;
+
+use yew::prelude::*;
+use yew::services::console::ConsoleService;
+use yew::services::router::{RouteInfo, RouterTask};
+
+use stdweb::web::Date;
+
+struct Context {
+    console: ConsoleService,
+}
+
+struct Model {
+    value: i64,
+    router: RouterTask<Context, Model>,
+}
+
+enum Msg {
+    Increment,
+    Decrement,
+    None,
+    Bulk(Vec<Msg>),
+}
+
+impl Component<Context> for Model {
+    type Msg = Msg;
+    type Properties = ();
+
+    fn create(_: Self::Properties, context: &mut Env<Context, Self>) -> Self {
+        Model {
+            value: 0,
+            router: RouterTask::new(context, &handle_route),
+        }
+    }
+
+    fn update(&mut self, msg: Self::Msg, context: &mut Env<Context, Self>) -> ShouldRender {
+        match msg {
+            Msg::Increment => {
+                self.value = self.value + 1;
+                context.console.log("plus one");
+            }
+            Msg::Decrement => {
+                self.value = self.value - 1;
+                context.console.log("minus one");
+            }
+            Msg::Bulk(list) => for msg in list {
+                self.update(msg, context);
+                context.console.log("Bulk action");
+            },
+            Msg::None => {
+                context.console.log("No action");
+                return false;
+            }
+        }
+        true
+    }
+}
+
+impl Renderable<Context, Model> for Model {
+    fn view(&self) -> Html<Context, Self> {
+        html! {
+            <div>
+                <p>
+                    <span>{ "Use the buttons below or go to "}</span>
+                    <a href="#increment",>{"#increment"}</a>
+                    <span>{" or "}</span>
+                    <a href="#decrement",>{"#decrement"}</a>
+                </p>
+                <nav class="menu",>
+                    <button onclick=|_| Msg::Increment,>{ "Increment" }</button>
+                    <button onclick=|_| Msg::Decrement,>{ "Decrement" }</button>
+                    <button onclick=|_| Msg::Bulk(vec![Msg::Increment, Msg::Increment]),>{ "Increment Twice" }</button>
+                </nav>
+                <p>{ self.value }</p>
+                <p>{ Date::new().to_string() }</p>
+            </div>
+        }
+    }
+}
+
+fn handle_route(info: RouteInfo) -> Msg {
+    let route = info.url.fragment().unwrap_or("");
+    println!("Handling route: {}", route);
+    if route.to_ascii_lowercase() == "increment" {
+        Msg::Increment
+    } else if route.to_ascii_lowercase() == "decrement" {
+        Msg::Decrement
+    } else {
+        Msg::None
+    }
+}
+
+fn main() {
+    yew::initialize();
+
+    let context = Context {
+        console: ConsoleService,
+    };
+
+    let app: App<_, Model> = App::new(context);
+    app.mount_to_body();
+    yew::run_loop();
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@ extern crate serde;
 extern crate serde_json;
 #[macro_use]
 extern crate stdweb;
+pub extern crate url;
 
 #[macro_use]
 pub mod macros;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -7,6 +7,7 @@ pub mod console;
 pub mod dialog;
 pub mod fetch;
 pub mod interval;
+pub mod router;
 pub mod storage;
 pub mod timeout;
 pub mod websocket;

--- a/src/services/router.rs
+++ b/src/services/router.rs
@@ -1,0 +1,120 @@
+//! This module contains the implementation of a service for
+//! a url router.
+
+use url::Url;
+
+use html::{Component, Env};
+use stdweb::Value;
+use stdweb::web::{self, IEventTarget};
+
+/// TODO:
+/// A handle which helps to cancel the router. Uses removeEventListener
+pub struct RouterTask<CTX: 'static, COMP: Component<CTX>> {
+    _handle1: web::EventListenerHandle,
+    handle2: Value,
+    history: web::History,
+    route_fn: &'static Fn(RouteInfo) -> COMP::Msg,
+}
+
+/// State of the current route.
+#[derive(Debug, Clone)]
+pub struct RouteInfo {
+    /// Url
+    pub url: Url,
+    /// History state
+    pub state: Value,
+}
+
+impl RouteInfo {
+    /// Initialize the route state using the current window.
+    fn new(url: Url, state: Value) -> RouteInfo {
+        RouteInfo {
+            url: url,
+            state: state,
+        }
+    }
+}
+
+fn current_url(window: &web::Window) -> Url {
+    // TODO: better error messages around unwraps
+    let href = window.location().unwrap().href().unwrap();
+    Url::parse(&href).unwrap()
+}
+
+impl<'a, CTX: 'a, COMP: Component<CTX>> RouterTask<CTX, COMP> {
+    /// Start the Routing Task in the environment.
+    ///
+    /// Ownership of this Task should typically be put in the `Model`.
+    ///
+    /// Routing will stop if this Task is dropped.
+    pub fn new(
+        env: &mut Env<'a, CTX, COMP>,
+        route_fn: &'static Fn(RouteInfo) -> COMP::Msg,
+    ) -> Self
+    {
+        let window = web::window();
+        let callback = env.send_back(route_fn);
+
+        let callback1 = callback.clone();
+        let callback2 = callback;
+
+        let cl_window = window.clone();
+        let handle1 = window
+            .add_event_listener(move |event: web::event::PopStateEvent| {
+                callback1.emit(RouteInfo::new(current_url(&cl_window), event.state()));
+            });
+
+        // TODO: koute/stdweb/issues/171
+        // self.handle2 = Some(self.window
+        //     .add_event_listener(move |_event: web::event::ResourceLoadEvent| {
+        //         callback2.emit(RouteInfo::new(Value::Null));
+        //     }));
+
+        let cl_window = window.clone();
+        let rs_handle = move || {
+            callback2.emit(RouteInfo::new(current_url(&cl_window), Value::Null));
+        };
+
+        let handle2 = js!{
+            var callback = @{rs_handle};
+            function listener() {
+                callback();
+            }
+            window.addEventListener("load", listener);
+            return {
+                callback: callback,
+                listener: listener
+            };
+        };
+
+        RouterTask {
+            _handle1: handle1,
+            handle2: handle2,
+            route_fn: route_fn,
+            history: window.history(),
+        }
+    }
+
+    /// Set the state of the history, including the url.
+    ///
+    /// This will _not_ trigger the router to change. If a state change is required
+    /// it is the user's job to propogate the `Msg`.
+    pub fn push_state(&self, state: Value, title: &str, url: Url) -> COMP::Msg {
+        self.history.push_state(state.clone(), title, Some(url.as_str()));
+        let info = RouteInfo {
+            url: url,
+            state: state,
+        };
+        (*self.route_fn)(info)
+    }
+}
+
+impl<CTX, COMP: Component<CTX>> Drop for RouterTask<CTX, COMP> {
+    fn drop(&mut self) {
+        js! { @(no_return)
+            var handle = @{&self.handle2};
+            window.removeEventListener("load", handle.listener);
+            handle.callback.drop();
+        }
+    }
+}


### PR DESCRIPTION
This is a very basic implementation of #184 and supports ONLY hash routers. It works _pretty well_ I think (check it out via counter_router).

I am investigating improving it to support HTML5 history as well, although I think just this implementation would be useful for 0.3.0 #93