### PR TITLE
replace all `unwrap/expect` with `expect!` macro.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ http = "0.1"
 serde = "1"
 serde_json = "1"
 stdweb = "0.4"
+expect_macro = "0.2.0"
 
 [dev-dependencies]
 serde_derive = "1"

--- a/src/html.rs
+++ b/src/html.rs
@@ -309,10 +309,10 @@ where
 {
     /// Alias to `mount("body", ...)`.
     pub fn mount_to_body(self) {
-        let element = document()
-            .query_selector("body")
-            .expect("can't get body node for rendering")
-            .expect("can't unwrap body node");
+        let body = expect!(
+            document().query_selector("body"),
+            "can't get body node for rendering");
+        let element = expect!(body, "can't unwrap body node");
         self.mount(element)
     }
 
@@ -349,9 +349,7 @@ where
             *cell.borrow_mut() = node;
         }
         let mut last_frame = Some(last_frame);
-        let rx = self.rx
-            .take()
-            .expect("application runned without a receiver");
+        let rx = expect!(self.rx.take(), "application ran without a receiver");
         let bind = self.bind.clone();
         let mut callback = move || {
             let mut should_update = false;
@@ -414,7 +412,7 @@ impl ScopeHandle {
 /// Removes anything from the given element.
 fn clear_element(element: &Element) {
     while let Some(child) = element.last_child() {
-        element.remove_child(&child).expect("can't remove a child");
+        expect!(element.remove_child(&child), "can't remove a child from {:?}", element);
     }
 }
 
@@ -456,7 +454,7 @@ macro_rules! impl_action {
 
                 fn attach(&mut self, element: &Element, mut sender: ScopeSender<CTX, COMP>)
                     -> EventListenerHandle {
-                    let handler = self.0.take().expect("tried to attach listener twice");
+                    let handler = expect!(self.0.take(), "tried to attach listener twice");
                     let this = element.clone();
                     let listener = move |event: $type| {
                         debug!("Event handler: {}", stringify!($type));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,8 @@
 #![recursion_limit = "256"]
 
 #[macro_use]
+extern crate expect_macro;
+#[macro_use]
 extern crate failure;
 extern crate http;
 extern crate serde;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -169,7 +169,7 @@ pub fn unpack<CTX, COMP: Component<CTX>>(mut stack: Stack<CTX, COMP>) -> VNode<C
     if stack.len() != 1 {
         panic!("exactly one element have to be in html!");
     }
-    stack.pop().expect("no html elements in the stack")
+    expect!(stack.pop(), "no html elements in the stack")
 }
 
 #[doc(hidden)]

--- a/src/services/interval.rs
+++ b/src/services/interval.rs
@@ -47,7 +47,7 @@ impl Task for IntervalTask {
         self.0.is_some()
     }
     fn cancel(&mut self) {
-        let handle = self.0.take().expect("tried to cancel interval twice");
+        let handle = expect!(self.0.take(), "tried to cancel interval twice");
         js! { @(no_return)
             var handle = @{handle};
             clearInterval(handle.interval_id);

--- a/src/services/storage.rs
+++ b/src/services/storage.rs
@@ -42,9 +42,7 @@ impl StorageService {
         T: Into<Storable>,
     {
         if let Some(data) = value.into() {
-            self.storage
-                .insert(key, &data)
-                .expect("can't insert value to a storage");
+            expect!(self.storage.insert(key, &data), "can't insert value to a storage");
         }
     }
 

--- a/src/services/timeout.rs
+++ b/src/services/timeout.rs
@@ -46,7 +46,7 @@ impl Task for TimeoutTask {
         self.0.is_some()
     }
     fn cancel(&mut self) {
-        let handle = self.0.take().expect("tried to cancel timeout twice");
+        let handle = expect!(self.0.take(), "tried to cancel timeout twice");
         js! { @(no_return)
             var handle = @{handle};
             clearTimeout(handle.timeout_id);

--- a/src/services/websocket.rs
+++ b/src/services/websocket.rs
@@ -100,7 +100,7 @@ impl Task for WebSocketTask {
         self.0.is_some()
     }
     fn cancel(&mut self) {
-        let handle = self.0.take().expect("tried to close websocket twice");
+        let handle = expect!(self.0.take(), "tried to close websocket twice");
         js! { @(no_return)
             var handle = @{handle};
             handle.socket.close();

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -52,7 +52,7 @@ impl<CTX: 'static, COMP: Component<CTX>> VComp<CTX, COMP> {
                     *Box::from_raw(raw)
                 };
 
-                let builder = builder.take().expect("tried to mount component twice");
+                let builder = expect!(builder.take(), "tried to mount component twice");
                 let opposite = obsolete.map(VNode::VRef);
                 builder.build(context).mount_in_place(
                     element,
@@ -73,7 +73,7 @@ impl<CTX: 'static, COMP: Component<CTX>> VComp<CTX, COMP> {
             let new_props = Some(props);
             // Ignore update till properties changed
             if previous_props != new_props {
-                let props = new_props.as_ref().unwrap().clone();
+                let props = expect!(new_props.as_ref()).clone();
                 sender.send(ComponentUpdate::Properties(props));
                 previous_props = new_props;
             }
@@ -105,9 +105,7 @@ impl<CTX: 'static, COMP: Component<CTX>> VComp<CTX, COMP> {
         for activator in &self.activators {
             *activator.borrow_mut() = Some(sender.clone());
         }
-        self.props
-            .take()
-            .expect("tried to activate properties twice")
+        expect!(self.props.take(), "tried to activate properties twice")
     }
 
     /// This methods gives sender from older node.
@@ -190,12 +188,13 @@ where
         opposite: Option<Node>,
         props: AnyProps,
     ) {
-        let element: Element = parent
+        let element: Element = expect!(parent
             .as_node()
             .as_ref()
             .to_owned()
-            .try_into()
-            .expect("element expected to mount VComp");
+            .try_into(),
+            "element expected to mount VComp"
+        );
         (self.generator)(context, element, opposite, props);
     }
 
@@ -222,9 +221,7 @@ where
         // Keep the sibling in the cell and send a message `Drop` to a loop
         self.cell.borrow_mut().take().and_then(|node| {
             let sibling = node.next_sibling();
-            parent
-                .remove_child(&node)
-                .expect("can't remove the component");
+            expect!(parent.remove_child(&node), "can't remove the component");
             sibling
         })
     }
@@ -270,9 +267,10 @@ where
                 // There is created an empty text node to be replaced with mount call.
                 let node = node.map(|sibling| {
                     let element = document().create_text_node("");
-                    parent
-                        .insert_before(&element, &sibling)
-                        .expect("can't insert dummy element for a component");
+                    expect!(
+                        parent.insert_before(&element, &sibling),
+                        "can't insert dummy element for a component"
+                    );
                     element.as_node().to_owned()
                 });
                 self.mount(env.context(), parent, node, any_props);

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -33,9 +33,7 @@ impl<CTX: 'static, COMP: Component<CTX>> VDiff for VNode<CTX, COMP> {
             VNode::VList(vlist) => vlist.remove(parent),
             VNode::VRef(node) => {
                 let sibling = node.next_sibling();
-                parent
-                    .remove_child(&node)
-                    .expect("can't remove node by VRef");
+                expect!(parent.remove_child(&node), "can't remove node by VRef");
                 sibling
             }
         }

--- a/src/virtual_dom/vtext.rs
+++ b/src/virtual_dom/vtext.rs
@@ -37,8 +37,10 @@ impl<CTX: 'static, COMP: Component<CTX>> VDiff for VText<CTX, COMP> {
 
     /// Remove VTag from parent.
     fn remove(self, parent: &Node) -> Option<Node> {
-        let node = self.reference
-            .expect("tried to remove not rendered VText from DOM");
+        let node = expect!(
+            self.reference,
+            "tried to remove not rendered VText from DOM"
+        );
         let sibling = node.next_sibling();
         if parent.remove_child(&node).is_err() {
             warn!("Node not found to remove VText");
@@ -82,9 +84,10 @@ impl<CTX: 'static, COMP: Component<CTX>> VDiff for VText<CTX, COMP> {
             Reform::Before(node) => {
                 let element = document().create_text_node(&self.text);
                 if let Some(sibling) = node {
-                    parent
-                        .insert_before(&element, &sibling)
-                        .expect("can't insert text before sibling");
+                    expect!(
+                        parent.insert_before(&element, &sibling),
+                        "can't insert text before sibling"
+                    );
                 } else {
                     parent.append_child(&element);
                 }


### PR DESCRIPTION
While trying to triage #201 there are a bunch of internal unwrap/expect errors -- but asm doesn't have the line number.

The expect macro just uses `panic` inline so you get the line number for "unwrap". It also helps make it easier to format a message.