### PR TITLE
No trail comma

### DIFF
--- a/examples/dashboard/src/lib.rs
+++ b/examples/dashboard/src/lib.rs
@@ -1,3 +1,5 @@
+#![recursion_limit = "128"]
+
 extern crate failure;
 #[macro_use]
 extern crate serde_derive;

--- a/examples/showcase/src/main.rs
+++ b/examples/showcase/src/main.rs
@@ -174,13 +174,13 @@ impl Renderable<Context, Scene> for Scene {
     fn view(&self) -> Html<Context, Self> {
         let _options = Scene::iter().map(|scene| {
             html! {
-                <option value={ scene.to_string() }, > { scene.to_string() } </option>
+                <option value={ scene.to_string() }> { scene.to_string() } </option>
             }
         });
 
         html! {
-            <div id="fullscreen",>
-                <div id="left_pane",>
+            <div id="fullscreen">
+                <div id="left_pane">
                     <h2>{ "Yew showcase" }</h2>
                     <select size="20", value={Scene::NotSelected.to_string()},
                         onchange=|cd: ChangeData| {
@@ -193,11 +193,11 @@ impl Renderable<Context, Scene> for Scene {
                                 _ => unreachable!(),
                             }
                         }
-                    , >
+                    >
                         { for _options }
                     </select>
                 </div>
-                <div id="right_pane",>
+                <div id="right_pane">
                     <h2>{ self.to_string() }</h2>
                     { self.view_scene() }
                 </div>

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -40,94 +40,100 @@ macro_rules! html_impl {
     ($stack:ident (< $starttag:ident $($tail:tt)*)) => {
         let vtag = $crate::virtual_dom::VTag::new(stringify!($starttag));
         $stack.push(vtag.into());
-        html_impl! { @vtag $stack ($($tail)*) }
+        html_impl! { @vtag $stack (, $($tail)*) }
     };
     // PATTERN: class=("class-1", "class-2"),
-    (@vtag $stack:ident (class = ($($class:expr),*), $($tail:tt)*)) => {
+    (@vtag $stack:ident (, class = ($($class:expr),*), $($tail:tt)*)) => {
         $( $crate::macros::attach_class(&mut $stack, $class); )*
-        html_impl! { @vtag $stack ($($tail)*) }
+        html_impl! { @vtag $stack (, $($tail)*) }
     };
-    (@vtag $stack:ident (class = $class:expr, $($tail:tt)*)) => {
+    (@vtag $stack:ident (, class = $class:expr, $($tail:tt)*)) => {
         $crate::macros::attach_class(&mut $stack, $class);
-        html_impl! { @vtag $stack ($($tail)*) }
+        html_impl! { @vtag $stack (, $($tail)*) }
     };
     // PATTERN: value="",
-    (@vtag $stack:ident (value = $value:expr, $($tail:tt)*)) => {
+    (@vtag $stack:ident (, value = $value:expr, $($tail:tt)*)) => {
         $crate::macros::set_value(&mut $stack, $value);
-        html_impl! { @vtag $stack ($($tail)*) }
+        html_impl! { @vtag $stack (, $($tail)*) }
     };
     // PATTERN: attribute=value, - workaround for `type` attribute
     // because `type` is a keyword in Rust
-    (@vtag $stack:ident (type = $kind:expr, $($tail:tt)*)) => {
+    (@vtag $stack:ident (, type = $kind:expr, $($tail:tt)*)) => {
         $crate::macros::set_kind(&mut $stack, $kind);
-        html_impl! { @vtag $stack ($($tail)*) }
+        html_impl! { @vtag $stack (, $($tail)*) }
     };
-    (@vtag $stack:ident (checked = $kind:expr, $($tail:tt)*)) => {
+    (@vtag $stack:ident (, checked = $kind:expr, $($tail:tt)*)) => {
         $crate::macros::set_checked(&mut $stack, $kind);
-        html_impl! { @vtag $stack ($($tail)*) }
+        html_impl! { @vtag $stack (, $($tail)*) }
     };
-    (@vtag $stack:ident (disabled = $kind:expr, $($tail:tt)*)) => {
+    (@vtag $stack:ident (, disabled = $kind:expr, $($tail:tt)*)) => {
         if $kind {
             $crate::macros::add_attribute(&mut $stack, "disabled", "true");
         }
-        html_impl! { @vtag $stack ($($tail)*) }
+        html_impl! { @vtag $stack (, $($tail)*) }
     };
     // Events:
-    (@vtag $stack:ident (onclick = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onclick) = $handler, $($tail)*) }
+    (@vtag $stack:ident (, onclick = $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack (, (onclick) = $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (onmousemove = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onmousemove) = $handler, $($tail)*) }
+    (@vtag $stack:ident (, onmousemove = $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack (, (onmousemove) = $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (ondoubleclick = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((ondoubleclick) = $handler, $($tail)*) }
+    (@vtag $stack:ident (, ondoubleclick = $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack (, (ondoubleclick) = $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (onkeypress = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onkeypress) = $handler, $($tail)*) }
+    (@vtag $stack:ident (, onkeypress = $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack (, (onkeypress) = $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (onkeydown = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onkeydown) = $handler, $($tail)*) }
+    (@vtag $stack:ident (, onkeydown = $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack (, (onkeydown) = $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (onkeyup = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onkeyup) = $handler, $($tail)*) }
+    (@vtag $stack:ident (, onkeyup = $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack (, (onkeyup) = $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (oninput = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((oninput) = $handler, $($tail)*) }
+    (@vtag $stack:ident (, oninput = $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack (, (oninput) = $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (onchange = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onchange) = $handler, $($tail)*) }
+    (@vtag $stack:ident (, onchange = $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack (, (onchange) = $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (onblur = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onblur) = $handler, $($tail)*) }
+    (@vtag $stack:ident (, onblur = $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack (, (onblur) = $handler, $($tail)*) }
     };
     // PATTERN: (action)=expression,
-    (@vtag $stack:ident (($action:ident) = $handler:expr, $($tail:tt)*)) => {
+    (@vtag $stack:ident (, ($action:ident) = $handler:expr, $($tail:tt)*)) => {
         // Catch value to a separate variable for clear error messages
         let handler = $handler;
         let listener = $crate::html::$action::Wrapper::from(handler);
         $crate::macros::attach_listener(&mut $stack, Box::new(listener));
-        html_impl! { @vtag $stack ($($tail)*) }
+        html_impl! { @vtag $stack (, $($tail)*) }
     };
     // Attributes:
-    (@vtag $stack:ident (href = $href:expr, $($tail:tt)*)) => {
+    (@vtag $stack:ident (, href = $href:expr, $($tail:tt)*)) => {
         let href: $crate::html::Href = $href.into();
         $crate::macros::add_attribute(&mut $stack, "href", href);
-        html_impl! { @vtag $stack ($($tail)*) }
+        html_impl! { @vtag $stack (, $($tail)*) }
     };
-    (@vtag $stack:ident ($attr:ident = $val:expr, $($tail:tt)*)) => {
+    (@vtag $stack:ident (, $attr:ident = $val:expr, $($tail:tt)*)) => {
         $crate::macros::add_attribute(&mut $stack, stringify!($attr), $val);
-        html_impl! { @vtag $stack ($($tail)*) }
+        html_impl! { @vtag $stack (, $($tail)*) }
     };
-    (@vtag $stack:ident ($($attr:ident)-+ = $val:expr, $($tail:tt)*)) => {
+    (@vtag $stack:ident (, $($attr:ident)-+ = $val:expr, $($tail:tt)*)) => {
         let attr = vec![$(stringify!($attr).to_string()),+].join("-");
         $crate::macros::add_attribute(&mut $stack, &attr, $val);
-        html_impl! { @vtag $stack ($($tail)*) }
+        html_impl! { @vtag $stack (, $($tail)*) }
     };
     // End of openging tag
+    (@vtag $stack:ident (, > $($tail:tt)*)) => {
+        html_impl! { @vtag $stack (> $($tail)*) }
+    };
     (@vtag $stack:ident (> $($tail:tt)*)) => {
         html_impl! { $stack ($($tail)*) }
     };
     // Self-closing of tag
+    (@vtag $stack:ident (, / > $($tail:tt)*)) => {
+        html_impl! { @vtag $stack (/ > $($tail)*) }
+    };
     (@vtag $stack:ident (/ > $($tail:tt)*)) => {
         $crate::macros::child_to_parent(&mut $stack, None);
         html_impl! { $stack ($($tail)*) }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -30,14 +30,14 @@ macro_rules! html_impl {
     };
     // Self-closing of tag
     (@vcomp $stack:ident $pair:ident (, / > $($tail:tt)*)) => {
-        html_impl! { @vcomp $stack $pair (/ > $($tail)*) }
-    };
-    (@vcomp $stack:ident $pair:ident (/ > $($tail:tt)*)) => {
         let (props, mut comp) = $pair;
         comp.set_props(props);
         $stack.push(comp.into());
         $crate::macros::child_to_parent(&mut $stack, None);
         html_impl! { $stack ($($tail)*) }
+    };
+    (@vcomp $stack:ident $pair:ident (/ > $($tail:tt)*)) => {
+        html_impl! { @vcomp $stack $pair (, / > $($tail)*) }
     };
     // Start of opening tag
     ($stack:ident (< $starttag:ident $($tail:tt)*)) => {
@@ -128,18 +128,18 @@ macro_rules! html_impl {
     };
     // End of openging tag
     (@vtag $stack:ident (, > $($tail:tt)*)) => {
-        html_impl! { @vtag $stack (> $($tail)*) }
+        html_impl! { $stack ($($tail)*) }
     };
     (@vtag $stack:ident (> $($tail:tt)*)) => {
-        html_impl! { $stack ($($tail)*) }
+        html_impl! { @vtag $stack (, > $($tail)*) }
     };
     // Self-closing of tag
     (@vtag $stack:ident (, / > $($tail:tt)*)) => {
-        html_impl! { @vtag $stack (/ > $($tail)*) }
-    };
-    (@vtag $stack:ident (/ > $($tail:tt)*)) => {
         $crate::macros::child_to_parent(&mut $stack, None);
         html_impl! { $stack ($($tail)*) }
+    };
+    (@vtag $stack:ident (/ > $($tail:tt)*)) => {
+        html_impl! { @vtag $stack (, / > $($tail)*) }
     };
     // Traditional tag closing
     ($stack:ident (< / $endtag:ident > $($tail:tt)*)) => {

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -19,16 +19,19 @@ macro_rules! html_impl {
     ($stack:ident (< $comp:ty : $($tail:tt)*)) => {
         #[allow(unused_mut)]
         let mut pair = $crate::virtual_dom::VComp::lazy::<$comp>();
-        html_impl! { @vcomp $stack pair ($($tail)*) }
+        html_impl! { @vcomp $stack pair (, $($tail)*) }
     };
-    (@vcomp $stack:ident $pair:ident ($attr:ident = $val:expr, $($tail:tt)*)) => {
+    (@vcomp $stack:ident $pair:ident (, $attr:ident = $val:expr, $($tail:tt)*)) => {
         // It cloned for ergonomics in templates. Attribute with
         // `self.param` value could be reused and sholdn't be cloned
         // by yourself
         ($pair.0).$attr = $crate::virtual_dom::vcomp::Transformer::transform(&mut $pair.1, $val);
-        html_impl! { @vcomp $stack $pair ($($tail)*) }
+        html_impl! { @vcomp $stack $pair (, $($tail)*) }
     };
     // Self-closing of tag
+    (@vcomp $stack:ident $pair:ident (, / > $($tail:tt)*)) => {
+        html_impl! { @vcomp $stack $pair (/ > $($tail)*) }
+    };
     (@vcomp $stack:ident $pair:ident (/ > $($tail:tt)*)) => {
         let (props, mut comp) = $pair;
         comp.set_props(props);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -118,6 +118,11 @@ macro_rules! html_impl {
         $crate::macros::add_attribute(&mut $stack, stringify!($attr), $val);
         html_impl! { @vtag $stack ($($tail)*) }
     };
+    (@vtag $stack:ident ($($attr:ident)-+ = $val:expr, $($tail:tt)*)) => {
+        let attr = vec![$(stringify!($attr).to_string()),+].join("-");
+        $crate::macros::add_attribute(&mut $stack, &attr, $val);
+        html_impl! { @vtag $stack ($($tail)*) }
+    };
     // End of openging tag
     (@vtag $stack:ident (> $($tail:tt)*)) => {
         html_impl! { $stack ($($tail)*) }
@@ -126,11 +131,6 @@ macro_rules! html_impl {
     (@vtag $stack:ident (/ > $($tail:tt)*)) => {
         $crate::macros::child_to_parent(&mut $stack, None);
         html_impl! { $stack ($($tail)*) }
-    };
-    (@vtag $stack:ident ($($attr:ident)-+ = $val:expr, $($tail:tt)*)) => {
-        let attr = vec![$(stringify!($attr).to_string()),+].join("-");
-        $crate::macros::add_attribute(&mut $stack, &attr, $val);
-        html_impl! { @vtag $stack ($($tail)*) }
     };
     // Traditional tag closing
     ($stack:ident (< / $endtag:ident > $($tail:tt)*)) => {


### PR DESCRIPTION
Trying to fix #98 
It's necessary to have a trailing comma to distinguish `>` of an expression and `>` as closing char of a tag.

I won't merge this PR, because it doesn't work. But it's helpful for history reasons:

```rust
error: chained comparison operators require parentheses
   --> src/main.rs:177:52
    |
177 |                 <option value={ scene.to_string() }> { scene.to_string() } </option>
    |                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
error: expected expression, found `/`
   --> src/main.rs:177:77
    |
177 |                 <option value={ scene.to_string() }> { scene.to_string() } </option>
    |                                                                             ^ expected expression
error: aborting due to 2 previous errors
error: Could not compile `showcase`.
```

I will fix this later in another way.