### PR TITLE
Use raw stdweb events for key- and mousevents

### DIFF
--- a/examples/crm/src/lib.rs
+++ b/examples/crm/src/lib.rs
@@ -199,7 +199,7 @@ impl Client {
             <input class=("new-client", "firstname"),
                    placeholder="First name",
                    value=&self.first_name,
-                   oninput=|e: InputData| Msg::UpdateFirstName(e.value),
+                   oninput=|e| Msg::UpdateFirstName(e.value),
                    />
         }
     }
@@ -212,7 +212,7 @@ impl Client {
             <input class=("new-client", "lastname"),
                    placeholder="Last name",
                    value=&self.last_name,
-                   oninput=|e: InputData| Msg::UpdateLastName(e.value),
+                   oninput=|e| Msg::UpdateLastName(e.value),
                    />
         }
     }

--- a/examples/game_of_life/src/lib.rs
+++ b/examples/game_of_life/src/lib.rs
@@ -218,11 +218,11 @@ where
                             { for self.cellules.iter().enumerate().map(view_cellule) }
                         </div>
                         <div class="game-buttons",>
-                            <button class="game-button", onclick=move|_| Msg::Random,>{ "Random" }</button>
-                            <button class="game-button", onclick=move|_| Msg::Step,>{ "Step" }</button>
-                            <button class="game-button", onclick=move|_| Msg::Start,>{ "Start" }</button>
-                            <button class="game-button", onclick=move|_| Msg::Stop,>{ "Stop" }</button>
-                            <button class="game-button", onclick=move|_| Msg::Reset,>{ "Reset" }</button>
+                            <button class="game-button", onclick=|_| Msg::Random,>{ "Random" }</button>
+                            <button class="game-button", onclick=|_| Msg::Step,>{ "Step" }</button>
+                            <button class="game-button", onclick=|_| Msg::Start,>{ "Start" }</button>
+                            <button class="game-button", onclick=|_| Msg::Stop,>{ "Stop" }</button>
+                            <button class="game-button", onclick=|_| Msg::Reset,>{ "Reset" }</button>
                         </div>
                     </section>
                 </section>
@@ -243,6 +243,6 @@ where
 {
     html! {
         <div class=("game-cellule", if cellule.life_state == LifeState::Alive { "cellule-live" } else { "cellule-dead" }),
-            onclick=move |_| Msg::ToggleCellule(idx),> </div>
+            onclick=|_| Msg::ToggleCellule(idx),> </div>
     }
 }

--- a/examples/large_table/src/lib.rs
+++ b/examples/large_table/src/lib.rs
@@ -49,7 +49,7 @@ where
     html! {
         <td
             class=square_class((column, row), selected),
-            onclick=move |_| Msg::Select(column, row),
+            onclick=|_| Msg::Select(column, row),
         >
         </td>
     }

--- a/examples/mount_point/src/lib.rs
+++ b/examples/mount_point/src/lib.rs
@@ -38,7 +38,7 @@ where
     fn view(&self) -> Html<CTX, Self> {
         html! {
             <div>
-                <input value=&self.name, oninput=|e: InputData| Msg::UpdateName(e.value), />
+                <input value=&self.name, oninput=|e| Msg::UpdateName(e.value), />
                 <p>{ self.name.chars().rev().collect::<String>() }</p>
             </div>
         }

--- a/examples/showcase/src/main.rs
+++ b/examples/showcase/src/main.rs
@@ -183,7 +183,7 @@ impl Renderable<Context, Scene> for Scene {
                 <div id="left_pane",>
                     <h2>{ "Yew showcase" }</h2>
                     <select size="20", value={Scene::NotSelected.to_string()},
-                        onchange=|cd: ChangeData| {
+                        onchange=|cd| {
                             let scene = match cd {
                                 ChangeData::Select(se) => se.value().unwrap(),
                                 _ => unreachable!()

--- a/examples/textarea/src/lib.rs
+++ b/examples/textarea/src/lib.rs
@@ -45,7 +45,7 @@ where
                 <div>
                     <textarea rows=5,
                         value=&self.value,
-                        oninput=|e: InputData| Msg::GotInput(e.value),
+                        oninput=|e| Msg::GotInput(e.value),
                         placeholder="placeholder",>
                     </textarea>
                      <button onclick=|_| Msg::Clicked,>{ "change value" }</button>

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -169,7 +169,7 @@ impl Model {
             <li>
                 <a class=if self.filter == flt { "selected" } else { "not-selected" },
                    href=&flt,
-                   onclick=move |_| Msg::SetFilter(flt.clone()),>
+                   onclick=|_| Msg::SetFilter(flt.clone()),>
                     { filter }
                 </a>
             </li>
@@ -186,8 +186,8 @@ impl Model {
             <input class="new-todo",
                    placeholder="What needs to be done?",
                    value=&self.value,
-                   oninput=|e: InputData| Msg::Update(e.value),
-                   onkeypress=|e: KeyPressEvent| {
+                   oninput=|e| Msg::Update(e.value),
+                   onkeypress=|e| {
                        if e.key() == "Enter" { Msg::Add } else { Msg::Nope }
                    }, />
             /* Or multiline:
@@ -206,9 +206,9 @@ where
     html! {
         <li class=if entry.editing == true { "editing" } else { "" },>
             <div class="view",>
-                <input class="toggle", type="checkbox", checked=entry.completed, onclick=move|_| Msg::Toggle(idx), />
-                <label ondoubleclick=move|_| Msg::ToggleEdit(idx),>{ &entry.description }</label>
-                <button class="destroy", onclick=move |_| Msg::Remove(idx), />
+                <input class="toggle", type="checkbox", checked=entry.completed, onclick=|_| Msg::Toggle(idx), />
+                <label ondoubleclick=|_| Msg::ToggleEdit(idx),>{ &entry.description }</label>
+                <button class="destroy", onclick=|_| Msg::Remove(idx), />
             </div>
             { view_entry_edit_input((idx, &entry)) }
         </li>
@@ -224,9 +224,9 @@ where
             <input class="edit",
                    type="text",
                    value=&entry.description,
-                   oninput=|e: InputData| Msg::UpdateEdit(e.value),
-                   onblur=move|_| Msg::Edit(idx),
-                   onkeypress=move |e: KeyPressEvent| {
+                   oninput=|e| Msg::UpdateEdit(e.value),
+                   onblur=|_| Msg::Edit(idx),
+                   onkeypress=|e| {
                       if e.key() == "Enter" { Msg::Edit(idx) } else { Msg::Nope }
                    }, />
         }

--- a/examples/todomvc/src/lib.rs
+++ b/examples/todomvc/src/lib.rs
@@ -187,8 +187,8 @@ impl Model {
                    placeholder="What needs to be done?",
                    value=&self.value,
                    oninput=|e: InputData| Msg::Update(e.value),
-                   onkeypress=|e: KeyData| {
-                       if e.key == "Enter" { Msg::Add } else { Msg::Nope }
+                   onkeypress=|e: KeyPressEvent| {
+                       if e.key() == "Enter" { Msg::Add } else { Msg::Nope }
                    }, />
             /* Or multiline:
             <ul>
@@ -226,8 +226,8 @@ where
                    value=&entry.description,
                    oninput=|e: InputData| Msg::UpdateEdit(e.value),
                    onblur=move|_| Msg::Edit(idx),
-                   onkeypress=move |e: KeyData| {
-                      if e.key == "Enter" { Msg::Edit(idx) } else { Msg::Nope }
+                   onkeypress=move |e: KeyPressEvent| {
+                      if e.key() == "Enter" { Msg::Edit(idx) } else { Msg::Nope }
                    }, />
         }
     } else {

--- a/src/html.rs
+++ b/src/html.rs
@@ -7,7 +7,7 @@ use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 use std::marker::PhantomData;
-use stdweb::web::event::{BlurEvent, IKeyboardEvent, IMouseEvent};
+use stdweb::web::event::{BlurEvent};
 use stdweb::web::{Element, EventListenerHandle, INode, Node};
 use stdweb::web::html_element::SelectElement;
 use virtual_dom::{Listener, VDiff, VNode};
@@ -310,12 +310,12 @@ macro_rules! impl_action {
 
 // Inspired by: http://package.elm-lang.org/packages/elm-lang/html/2.0.0/Html-Events
 impl_action! {
-    onclick(event: ClickEvent) -> MouseData => |_, event| { MouseData::from(event) }
-    ondoubleclick(event: DoubleClickEvent) -> MouseData => |_, event| { MouseData::from(event) }
-    onkeypress(event: KeyPressEvent) -> KeyData => |_, event| { KeyData::from(event) }
-    onkeydown(event: KeyDownEvent) -> KeyData => |_, event| { KeyData::from(event) }
-    onkeyup(event: KeyUpEvent) -> KeyData => |_, event| { KeyData::from(event) }
-    onmousemove(event: MouseMoveEvent) -> MouseData => |_, event| { MouseData::from(event) }
+    onclick(event: ClickEvent) -> ClickEvent => |_, event| { event }
+    ondoubleclick(event: DoubleClickEvent) -> DoubleClickEvent => |_, event| { event }
+    onkeypress(event: KeyPressEvent) -> KeyPressEvent => |_, event| { event }
+    onkeydown(event: KeyDownEvent) -> KeyDownEvent => |_, event| { event }
+    onkeyup(event: KeyUpEvent) -> KeyUpEvent => |_, event| { event }
+    onmousemove(event: MouseMoveEvent) -> MouseMoveEvent => |_, event| { event }
     /* TODO Add PR to https://github.com/koute/stdweb
     onmousedown(event: MouseDownEvent) -> () => |_, _| { () }
     onmouseup(event: MouseUpEvent) -> () => |_, _| { () }
@@ -324,9 +324,7 @@ impl_action! {
     onmouseover(event: MouseOverEvent) -> () => |_, _| { () }
     onmouseout(event: MouseOutEvent) -> () => |_, _| { () }
     */
-    onblur(event: BlurEvent) -> BlurData => |_, event| {
-        BlurData::from(event)
-    }
+    onblur(event: BlurEvent) -> BlurEvent => |_, event| { event }
     oninput(event: InputEvent) -> InputData => |this: &Element, _| {
         use stdweb::web::html_element::{InputElement, TextAreaElement};
         use stdweb::unstable::TryInto;
@@ -372,42 +370,6 @@ impl_action! {
     }
 }
 
-/// A type representing data from `onclick` and `ondoubleclick` event.
-#[derive(Debug)]
-pub struct MouseData {
-    /// The screenX is a read-only property of the
-    /// [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/screenX)
-    /// property which provides the horizontal coordinate (offset)
-    /// of the mouse pointer in global (screen) coordinates.
-    pub screen_x: i32,
-    /// The screenY is a read-only property of the
-    /// [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/screenY)
-    /// property which provides the vertical coordinate (offset)
-    /// of the mouse pointer in global (screen) coordinates.
-    pub screen_y: i32,
-    /// The clientX is a read-only property of the
-    /// [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientX)
-    /// interface which provides the horizontal coordinate within
-    /// the application's client area at which the event occurred
-    pub client_x: i32,
-    /// The clientY is a read-only property of the
-    /// [MouseEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/clientX)
-    /// interface which provides the vertical coordinate within
-    /// the application's client area at which the event occurred
-    pub client_y: i32,
-}
-
-impl<T: IMouseEvent> From<T> for MouseData {
-    fn from(event: T) -> Self {
-        MouseData {
-            screen_x: event.screen_x(),
-            screen_y: event.screen_y(),
-            client_x: event.client_x(),
-            client_y: event.client_y(),
-        }
-    }
-}
-
 /// A type representing data from `oninput` event.
 #[derive(Debug)]
 pub struct InputData {
@@ -432,20 +394,6 @@ pub enum ChangeData {
     /// to collect your required data such as: `value`, `selected_index`, `selected_indices` or
     /// `selected_values`. You can also iterate throught `selected_options` yourself.
     Select(SelectElement),
-}
-
-/// A type representing data from `onkeypress` event.
-#[derive(Debug)]
-pub struct KeyData {
-    /// Value of a pressed key. Contains key name from
-    /// [KeyboardEvent](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key).
-    pub key: String,
-}
-
-impl<T: IKeyboardEvent> From<T> for KeyData {
-    fn from(event: T) -> Self {
-        KeyData { key: event.key() }
-    }
 }
 
 /// A type representing `onblur` event.

--- a/src/html.rs
+++ b/src/html.rs
@@ -7,7 +7,6 @@ use std::cell::RefCell;
 use std::ops::{Deref, DerefMut};
 use std::rc::Rc;
 use std::marker::PhantomData;
-use stdweb::web::event::{BlurEvent};
 use stdweb::web::{Element, EventListenerHandle, INode, Node};
 use stdweb::web::html_element::SelectElement;
 use virtual_dom::{Listener, VDiff, VNode};
@@ -394,16 +393,6 @@ pub enum ChangeData {
     /// to collect your required data such as: `value`, `selected_index`, `selected_indices` or
     /// `selected_values`. You can also iterate throught `selected_options` yourself.
     Select(SelectElement),
-}
-
-/// A type representing `onblur` event.
-#[derive(Debug)]
-pub struct BlurData;
-
-impl From<BlurEvent> for BlurData {
-    fn from(_: BlurEvent) -> Self {
-        BlurData
-    }
 }
 
 /// A bridging type for checking `href` attribute value.

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -73,32 +73,32 @@ macro_rules! html_impl {
         html_impl! { @vtag $stack ($($tail)*) }
     };
     // Events:
-    (@vtag $stack:ident (onclick = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onclick) = $handler, $($tail)*) }
+    (@vtag $stack:ident (onclick = | $var:pat | $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack ((onclick) = move | $var: $crate::prelude::ClickEvent | $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (onmousemove = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onmousemove) = $handler, $($tail)*) }
+    (@vtag $stack:ident (ondoubleclick = | $var:pat | $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack ((ondoubleclick) = move | $var: $crate::prelude::DoubleClickEvent | $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (ondoubleclick = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((ondoubleclick) = $handler, $($tail)*) }
+    (@vtag $stack:ident (onkeypress = | $var:pat | $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack ((onkeypress) = move | $var: $crate::prelude::KeyPressEvent | $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (onkeypress = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onkeypress) = $handler, $($tail)*) }
+    (@vtag $stack:ident (onkeydown = | $var:pat | $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack ((onkeydown) = move | $var: $crate::prelude::KeyDownEvent | $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (onkeydown = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onkeydown) = $handler, $($tail)*) }
+    (@vtag $stack:ident (onkeyup = | $var:pat | $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack ((onkeyup) = move | $var: $crate::prelude::KeyUpEvent | $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (onkeyup = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onkeyup) = $handler, $($tail)*) }
+    (@vtag $stack:ident (onmousemove = | $var:pat | $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack ((onmousemove) = move | $var: $crate::prelude::MouseMoveEvent | $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (oninput = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((oninput) = $handler, $($tail)*) }
+    (@vtag $stack:ident (onblur = | $var:pat | $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack ((onblur) = move | $var: $crate::prelude::BlurEvent | $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (onchange = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onchange) = $handler, $($tail)*) }
+    (@vtag $stack:ident (oninput = | $var:pat | $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack ((oninput) = move | $var: $crate::prelude::InputData | $handler, $($tail)*) }
     };
-    (@vtag $stack:ident (onblur = $handler:expr, $($tail:tt)*)) => {
-        html_impl! { @vtag $stack ((onblur) = $handler, $($tail)*) }
+    (@vtag $stack:ident (onchange = | $var:pat | $handler:expr, $($tail:tt)*)) => {
+        html_impl! { @vtag $stack ((onchange) = move | $var: $crate::prelude::ChangeData | $handler, $($tail)*) }
     };
     // PATTERN: (action)=expression,
     (@vtag $stack:ident (($action:ident) = $handler:expr, $($tail:tt)*)) => {

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -24,12 +24,13 @@ pub use app::App;
 pub use callback::Callback;
 
 pub use stdweb::web::event::{
-    ClickEvent, 
-    DoubleClickEvent, 
+    BlurEvent,
+    ClickEvent,
+    DoubleClickEvent,
     IKeyboardEvent,
     IMouseEvent,
-    KeyDownEvent, 
-    KeyPressEvent, 
-    KeyUpEvent, 
-    MouseMoveEvent, 
+    KeyDownEvent,
+    KeyPressEvent,
+    KeyUpEvent,
+    MouseMoveEvent,
 };

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -6,6 +6,7 @@
 //! # #![allow(unused_imports)]
 //! use yew::prelude::*;
 //! ```
+extern crate stdweb;
 
 pub use html::{
     Component,
@@ -14,8 +15,6 @@ pub use html::{
     Html,
     ChangeData,
     InputData,
-    KeyData,
-    MouseData,
     Renderable,
     ShouldRender,
 };
@@ -23,3 +22,14 @@ pub use html::{
 pub use app::App;
 
 pub use callback::Callback;
+
+pub use stdweb::web::event::{
+    ClickEvent, 
+    DoubleClickEvent, 
+    IKeyboardEvent,
+    IMouseEvent,
+    KeyDownEvent, 
+    KeyPressEvent, 
+    KeyUpEvent, 
+    MouseMoveEvent, 
+};


### PR DESCRIPTION
As discussed in #235 I removed the custom event wrappers for KeyData and MouseData.

I added also the corresponding `stdweb` events to the exports of the `prelude` module and adapted the "new" events in the todomvc example.

I hope my changes are ok.