### PR TITLE
If the request is binary, make sure the body is a valid type

### DIFF
--- a/src/services/fetch.rs
+++ b/src/services/fetch.rs
@@ -161,9 +161,13 @@ where
     };
 
     let handle = js! {
+        var body = @{body};
+        if (@{binary} && body != null) {
+            body = Uint8Array.from(body);
+        }
         var data = {
             method: @{method},
-            body: @{body},
+            body: body,
             headers: @{header_map},
         };
         var request = new Request(@{uri}, data);


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Request/Request states:

> body: Any body that you want to add to your request: this can be a Blob, BufferSource, FormData, URLSearchParams, USVString, or ReadableStream object. Note that a request using the GET or HEAD method cannot have a body.

However, at present the body (in binary mode) is just a standard JS array and so (in my testing) gets completely dropped and not sent when using `fetch_binary`. To fix this it now does an in-JS conversion to a typed array, one of the valid forms.

I also considered:
1. stdweb `UnsafeTypedArray` - not viable because we cannot guarantee that the request has finished before returning to Rust code
2. Making the call to `fetch_impl` require a conversion to `TypedArray<u8>` rather than `Vec<u8>`, but that then started me needing to think about changing trait bounds and I just wanted to make a quick PR :)