### PR TITLE
Add error handling for npm_and_rest example

### DIFF
--- a/examples/npm_and_rest/src/gravatar.rs
+++ b/examples/npm_and_rest/src/gravatar.rs
@@ -33,8 +33,13 @@ impl GravatarService {
     pub fn profile(&mut self, hash: &str, callback: Callback<Result<Profile, Error>>) -> FetchTask {
         let url = format!("https://gravatar.com/{}", hash);
         let handler = move |response: Response<Json<Result<Profile, Error>>>| {
-            let (_, Json(data)) = response.into_parts();
-            callback.emit(data)
+            let (meta, Json(data)) = response.into_parts();
+            if meta.status.is_success() {
+                callback.emit(data)
+            } else {
+                // format_err! is a macro in crate `failure`
+                callback.emit(Err(format_err!("{}: error getting profile https://gravatar.com/", meta.status)))
+            }
         };
         let request = Request::get(url.as_str()).body(Nothing).unwrap();
         self.web.fetch(request, handler.into())

--- a/examples/npm_and_rest/src/lib.rs
+++ b/examples/npm_and_rest/src/lib.rs
@@ -1,3 +1,4 @@
+#[macro_use]
 extern crate failure;
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
For example of `fetch` service, there is some more in depth portion of code in `examples/dashboard` but I was overwhelmed by the size (number of lines of code) of that example. I try `fetch` example in `npm_and_rest` because it is much simpler to understand, but something went wrong and it took me some hours to figure out what is missing. 

So I added the error handling to make it clear that there are something to check there. (For anyone like me - that the `Error` in `Response<Json<Result<Profile, Error>>>` is not enough)