### PR TITLE
Force the nightly version of cargo on web command

### DIFF
--- a/examples/build_all.sh
+++ b/examples/build_all.sh
@@ -13,7 +13,7 @@ function build() {
         echo "Building: $example"
         cd $example
         cargo update
-        cargo web build --target wasm32-unknown-unknown
+        cargo +nightly web build --target wasm32-unknown-unknown
         cd ..
     done
 }
@@ -26,7 +26,7 @@ function run() {
         fi
         echo "Running: $example"
         cd $example
-        cargo web start --target wasm32-unknown-unknown &
+        cargo +nightly web start --target wasm32-unknown-unknown &
         PID=$!
         wait $PID
         cd ..


### PR DESCRIPTION
Some users (like me) does not default to nightly version.

I install stable and nightly, default to stable. and use `cargo +nightly`
for projects that requires nightly features.

I always take a look to examples before diving projects, so I guess it is better
for every new users if the build script does not failed if you don't default to nigthly.

