### PR TITLE
Make Tasks Transferable

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -20,23 +20,11 @@ enum ToWorker<T> {
     Destroy,
 }
 
-impl<T> Transferable for ToWorker<T>
-where
-    T: Serialize + for <'de> Deserialize<'de>,
-{
-}
-
 #[derive(Serialize, Deserialize)]
 enum FromWorker<T> {
     /// Worker sends this message when `wasm` bundle has loaded.
     WorkerLoaded,
     ProcessOutput(HandlerId, T),
-}
-
-impl<T> Transferable for FromWorker<T>
-where
-    T: Serialize + for <'de> Deserialize<'de>,
-{
 }
 
 
@@ -46,6 +34,8 @@ where
     Self: Serialize + for <'de> Deserialize<'de>,
 {
 }
+
+impl <T> Transferable for T where T: Serialize + for<'de> Deserialize<'de> {}
 
 trait Packed {
     fn pack(&self) -> Vec<u8>;

--- a/src/services/fetch.rs
+++ b/src/services/fetch.rs
@@ -20,6 +20,7 @@ enum FetchError {
 }
 
 /// A handle to control sent requests. Can be canceled with a `Task::cancel` call.
+#[derive(Serialize, Deserialize)]
 pub struct FetchTask(Option<Value>);
 
 /// A service to fetch resources.

--- a/src/services/interval.rs
+++ b/src/services/interval.rs
@@ -8,6 +8,7 @@ use stdweb::Value;
 
 /// A handle which helps to cancel interval. Uses
 /// [clearInterval](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/clearInterval).
+#[derive(Serialize, Deserialize)]
 pub struct IntervalTask(Option<Value>);
 
 /// A service to send messages on every elapsed interval.

--- a/src/services/timeout.rs
+++ b/src/services/timeout.rs
@@ -7,6 +7,7 @@ use std::time::Duration;
 use stdweb::Value;
 
 /// A handle to cancel a timeout task.
+#[derive(Serialize, Deserialize)]
 pub struct TimeoutTask(Option<Value>);
 
 /// An service to set a timeout.


### PR DESCRIPTION
For context: 
I want to write an agent that will accept enums representing requests to be made as inputs, will communicate with other agents and services to manage things like `JWT` authorization and app route redirection, and then make the request and return a `FetchTask` to the actor that called it.

It would look something like: 
```rust
impl <T> Agent for FetchAgent<T>
    where T: FetchRequest + Transferable
{
    type Reach = Context;
    type Message = ();
    type Input = T;
    type Output = Result<FetchTask, MyFetchError>;
...
}
```

Unfortunately, this isn't possible because the Output must be `Transferable`, and `FetchTask` is not. 

This PR derives `Serialize` and `Deserialize` for the tasks that can support it. Sadly, this could not be done for the websocket task, because `std::web::WebSocket` is not serializeable and deserializeable.