### PR TITLE
Add shared type of agent

### DIFF
--- a/examples/multi_thread/src/bin/shared_worker.rs
+++ b/examples/multi_thread/src/bin/shared_worker.rs
@@ -1,14 +1,13 @@
-
 extern crate web_logger;
 extern crate yew;
 extern crate multi_thread;
 
 use yew::prelude::*;
-use multi_thread::native_worker;
+use multi_thread::shared_worker;
 
 fn main() {
     web_logger::init();
     yew::initialize();
-    native_worker::Worker::register();
+    shared_worker::Worker::register();
     yew::run_loop();
 }

--- a/examples/multi_thread/src/bin/thread_worker.rs
+++ b/examples/multi_thread/src/bin/thread_worker.rs
@@ -1,0 +1,13 @@
+extern crate web_logger;
+extern crate yew;
+extern crate multi_thread;
+
+use yew::prelude::*;
+use multi_thread::thread_worker;
+
+fn main() {
+    web_logger::init();
+    yew::initialize();
+    thread_worker::Worker::register();
+    yew::run_loop();
+}

--- a/examples/multi_thread/src/shared_worker.rs
+++ b/examples/multi_thread/src/shared_worker.rs
@@ -1,0 +1,71 @@
+use std::time::Duration;
+use yew::prelude::worker::*;
+// TODO use yew::services::{IntervalService, FetchService, Task};
+use yew::services::Task;
+use yew::services::interval::IntervalService;
+use yew::services::fetch::FetchService;
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum Request {
+    GetDataFromServer,
+}
+
+impl Transferable for Request { }
+
+#[derive(Serialize, Deserialize, Debug)]
+pub enum Response {
+    DataFetched,
+}
+
+impl Transferable for Response { }
+
+pub enum Msg {
+    Updating,
+}
+
+pub struct Worker {
+    link: AgentLink<Worker>,
+    interval: IntervalService,
+    task: Box<Task>,
+    fetch: FetchService,
+}
+
+impl Agent for Worker {
+    type Reach = Global;
+    type Message = Msg;
+    type Input = Request;
+    type Output = Response;
+
+    fn create(link: AgentLink<Self>) -> Self {
+        let mut interval = IntervalService::new();
+        let duration = Duration::from_secs(3);
+        let callback = link.send_back(|_| Msg::Updating);
+        let task = interval.spawn(duration, callback);
+        Worker {
+            link,
+            interval,
+            task: Box::new(task),
+            fetch: FetchService::new(),
+        }
+    }
+
+    fn update(&mut self, msg: Self::Message) {
+        match msg {
+            Msg::Updating => {
+                info!("Tick...");
+            }
+        }
+    }
+
+    fn handle(&mut self, msg: Self::Input, who: HandlerId) {
+        info!("Request: {:?}", msg);
+        match msg {
+            Request::GetDataFromServer => {
+                self.link.response(who, Response::DataFetched);
+            }
+        }
+    }
+
+    fn name_of_resource() -> &'static str { "bin/shared_worker.js" }
+}
+

--- a/examples/multi_thread/src/thread_worker.rs
+++ b/examples/multi_thread/src/thread_worker.rs
@@ -66,5 +66,5 @@ impl Agent for Worker {
         }
     }
 
-    fn name_of_resource() -> &'static str { "bin/native_worker.js" }
+    fn name_of_resource() -> &'static str { "bin/thread_worker.js" }
 }


### PR DESCRIPTION
I've started working on the implementation of `Global` type of agent. This type will use [`SharedWorker`](https://developer.mozilla.org/en-US/docs/Web/API/SharedWorker) and could be used from multiple tabs of a browser.

It's the last type of agent I want to implement before **release 0.5**.