### PR TITLE
Support text node as a root

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -169,6 +169,13 @@ macro_rules! html_impl {
         $crate::macros::child_to_parent(&mut $stack, None);
         html_impl! { $stack ($($tail)*) }
     };
+    // Support root text nodes: #313
+    // Provides `html!` blocks with only expression inside
+    ($stack:ident ({ $eval:expr })) => {
+        let node = $crate::virtual_dom::VNode::from($eval);
+        $stack.push(node);
+        html_impl! { $stack () }
+    };
     // PATTERN: { expression }
     ($stack:ident ({ $eval:expr } $($tail:tt)*)) => {
         let node = $crate::virtual_dom::VNode::from($eval);
@@ -287,7 +294,7 @@ pub fn add_child<COMP: Component>(stack: &mut Stack<COMP>, child: VNode<COMP>) {
             vlist.add_child(child);
         }
         _ => {
-            panic!("no nodes in stack to add child: {:?}", child);
+            panic!("parent must be a tag or a fragment to add the node: {:?}", child);
         }
     }
 }

--- a/tests/vtext_test.rs
+++ b/tests/vtext_test.rs
@@ -1,0 +1,34 @@
+#[macro_use]
+extern crate yew;
+
+use yew::prelude::*;
+use yew::virtual_dom::VNode;
+
+struct Comp;
+
+impl Component for Comp {
+    type Message = ();
+    type Properties = ();
+
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+        Comp
+    }
+
+    fn update(&mut self, _: Self::Message) -> ShouldRender {
+        unimplemented!();
+    }
+}
+
+impl Renderable<Comp> for Comp {
+    fn view(&self) -> Html<Self> {
+        unimplemented!();
+    }
+}
+
+#[test]
+fn text_as_root() {
+    let _: VNode<Comp> = html! {
+        { "Text Node As Root" }
+    };
+}
+


### PR DESCRIPTION
Sometimes it's necessary to create text nodes without parents to render Rust expressions.
Fixes #313 