### PR TITLE
Fetch with cookies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@
 - `html!` macro supports multiple classes in a single string. For example:
   `<a class="button is-primary",>{ "Send" }</a>`.
 
+- `Added `FetchOptions` to set `Credentials` of `fetch` request.
+
 [Web Workers API]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API
 
 ### Bug fixes

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-[![Build Status](https://api.travis-ci.org/DenisKolodin/yew.svg)](https://travis-ci.org/DenisKolodin/yew)[![Gitter chat](https://badges.gitter.im/yewframework.png)](https://gitter.im/yewframework/Lobby "Gitter chat")
+[![Build Status](https://api.travis-ci.org/DenisKolodin/yew.svg)](https://travis-ci.org/DenisKolodin/yew)
+[![Gitter chat](https://badges.gitter.im/yewframework.png)](https://gitter.im/yewframework/Lobby "Gitter chat")
 
 # Yew
 


### PR DESCRIPTION
This PR adds init options for `fetch()` request. Only `credentials` supported in these changes.
https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch

Related: https://github.com/koute/stdweb/issues/67

_Bonus:_ Badges reordered in `README.md`.