### PR TITLE
Fix render order for fragments

### DIFF
--- a/examples/fragments/src/lib.rs
+++ b/examples/fragments/src/lib.rs
@@ -44,8 +44,11 @@ impl Renderable<Model> for Model {
                 <nav class="menu",>{ self.view_menu() }</nav>
                 <table>
                     <tr>
+                        // Important! All columns have contain the same elements
                         { self.view_cols() }
+                        <td>{ "- - - >" }</td>
                         { self.view_cols() }
+                        <td>{ "< - - -" }</td>
                         { self.view_cols() }
                     </tr>
                 </table>
@@ -59,10 +62,8 @@ impl Model {
         let render = |idx| html! {
             <td>{ idx }</td>
         };
-        html! {
-            <>
-                { for (0..self.counter).map(render) }
-            </>
+        html! { // We use a fragment directly
+            { for (0..self.counter).map(render) }
         }
     }
 

--- a/examples/game_of_life/src/lib.rs
+++ b/examples/game_of_life/src/lib.rs
@@ -26,6 +26,7 @@ pub struct Model {
     cellules: Vec<Cellule>,
     cellules_width: usize,
     cellules_height: usize,
+    #[allow(unused)]
     job: Box<Task>,
 }
 

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -359,7 +359,7 @@ impl<COMP: Component> VDiff for VTag<COMP> {
                     }
                 }
                 Some(mut vnode) => {
-                    // It is not even a VTag, we must remove the ancestor.
+                    // It is not a VTag variant we must remove the ancestor.
                     let node = vnode.detach(parent);
                     (Reform::Before(node), None)
                 }


### PR DESCRIPTION
Fix the bug when a fragment is the first in a tree.
The old code works wrong for templates like:

```rust
html! {
    <div>
        { for empty_list_for_first_render.iter().map(view_item) }
        <p>{ "Paragraph" }</p>
    </div>
}
```