### PR TITLE
Implement Default for Callback

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -30,6 +30,12 @@ impl<IN> PartialEq for Callback<IN> {
     }
 }
 
+impl<IN> Default for Callback<IN> {
+    fn default() -> Self {
+        Callback::from(|_| {})
+    }
+}
+
 impl<IN> Callback<IN> {
     /// This method calls the actual callback.
     pub fn emit(&self, value: IN) {


### PR DESCRIPTION
This allows using `#[derive(Default)]` in more cases for `Properties`.