### PR TITLE
Require mutable reference for send_back method call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,11 @@
   All examples had changed.
 
 - `html!` macro adds `move` modifier and the type of event for every handler (#240). Use
-`<input oninput=|e| Msg::UpdateEvent(e.value), />` instead of obsolete
-`<input oninput=move |e: InputData| Msg::UpdateEvent(e.value), />`.
+  `<input oninput=|e| Msg::UpdateEvent(e.value), />` instead of obsolete
+  `<input oninput=move |e: InputData| Msg::UpdateEvent(e.value), />`.
+
+- `send_back` method requires a mutable reference to `self`. This was added to prevent creating
+  callbacks in `view` implementations.
 
 ### New features
 

--- a/examples/game_of_life/src/lib.rs
+++ b/examples/game_of_life/src/lib.rs
@@ -156,7 +156,7 @@ impl Component for Model {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: Self::Properties, mut link: ComponentLink<Self>) -> Self {
         let callback = link.send_back(|_| Msg::Tick);
         let mut interval = IntervalService::new();
         let handle = interval.spawn(Duration::from_millis(200), callback);

--- a/examples/npm_and_rest/src/lib.rs
+++ b/examples/npm_and_rest/src/lib.rs
@@ -37,7 +37,7 @@ impl Component for Model {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: Self::Properties, mut link: ComponentLink<Self>) -> Self {
         Model {
             gravatar: GravatarService::new(),
             ccxt: CcxtService::new(),

--- a/examples/timer/src/lib.rs
+++ b/examples/timer/src/lib.rs
@@ -28,7 +28,7 @@ impl Component for Model {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: Self::Properties, mut link: ComponentLink<Self>) -> Self {
         // This callback doesn't send any message to a scope
         let callback = |_| {
             println!("Example of a standalone callback.");

--- a/src/html.rs
+++ b/src/html.rs
@@ -72,7 +72,7 @@ where
     }
 
     /// This method sends messages back to the component's loop.
-    pub fn send_back<F, IN>(&self, function: F) -> Callback<IN>
+    pub fn send_back<F, IN>(&mut self, function: F) -> Callback<IN>
     where
         F: Fn(IN) -> COMP::Message + 'static,
     {


### PR DESCRIPTION
This PR is separated from #365 to buy time to make backward incompatible changes.