### PR TITLE
Deny deprecated

### DIFF
--- a/src/callback.rs
+++ b/src/callback.rs
@@ -10,7 +10,7 @@ use std::rc::Rc;
 /// </aside>
 /// `Rc` wrapper used to make it clonable.
 #[must_use]
-pub struct Callback<IN>(Rc<Fn(IN)>);
+pub struct Callback<IN>(Rc<dyn Fn(IN)>);
 
 impl<IN, F: Fn(IN) + 'static> From<F> for Callback<IN> {
     fn from(func: F) -> Self {

--- a/src/html.rs
+++ b/src/html.rs
@@ -114,7 +114,7 @@ where
             shared_component: self.shared_component.clone(),
             message: Some(update),
         };
-        let runnable: Box<Runnable> = Box::new(envelope);
+        let runnable: Box<dyn Runnable> = Box::new(envelope);
         scheduler().put_and_try_run(runnable);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //! ```
 //!
 
-#![deny(missing_docs, bare_trait_objects)]
+#![deny(missing_docs, bare_trait_objects, anonymous_parameters)]
 #![recursion_limit = "512"]
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,15 +11,15 @@
 //! #[macro_use]
 //! extern crate yew;
 //! use yew::prelude::*;
-//! 
+//!
 //! struct Model {
 //!     value: i64,
 //! }
-//! 
+//!
 //! enum Msg {
 //!     DoIt,
 //! }
-//! 
+//!
 //! impl Component for Model {
 //!     type Message = Msg;
 //!     type Properties = ();
@@ -28,7 +28,7 @@
 //!             value: 0,
 //!         }
 //!     }
-//! 
+//!
 //!     fn update(&mut self, msg: Self::Message) -> ShouldRender {
 //!         match msg {
 //!             Msg::DoIt => self.value = self.value + 1
@@ -36,7 +36,7 @@
 //!         true
 //!     }
 //! }
-//! 
+//!
 //! impl Renderable<Model> for Model {
 //!     fn view(&self) -> Html<Self> {
 //!         html! {
@@ -47,7 +47,7 @@
 //!         }
 //!     }
 //! }
-//! 
+//!
 //! fn main() {
 //!     yew::initialize();
 //!     App::<Model>::new().mount_to_body();
@@ -56,7 +56,7 @@
 //! ```
 //!
 
-#![deny(missing_docs)]
+#![deny(missing_docs, bare_trait_objects)]
 #![recursion_limit = "512"]
 
 #[macro_use]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -290,7 +290,7 @@ pub fn set_classes<COMP: Component, T: AsRef<str>>(stack: &mut Stack<COMP>, clas
 #[doc(hidden)]
 pub fn attach_listener<COMP: Component>(
     stack: &mut Stack<COMP>,
-    listener: Box<Listener<COMP>>,
+    listener: Box<dyn Listener<COMP>>,
 ) {
     if let Some(&mut VNode::VTag(ref mut vtag)) = stack.last_mut() {
         vtag.add_listener(listener);

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -24,7 +24,7 @@ pub(crate) trait Runnable {
 /// This is a global scheduler suitable to schedule and run any tasks.
 pub(crate) struct Scheduler {
     lock: Rc<AtomicBool>,
-    sequence: Shared<VecDeque<Box<Runnable>>>,
+    sequence: Shared<VecDeque<Box<dyn Runnable>>>,
 }
 
 impl Clone for Scheduler {
@@ -46,7 +46,7 @@ impl Scheduler {
         }
     }
 
-    pub(crate) fn put_and_try_run(&self, runnable: Box<Runnable>) {
+    pub(crate) fn put_and_try_run(&self, runnable: Box<dyn Runnable>) {
         self.sequence.borrow_mut().push_back(runnable);
         if self.lock.compare_and_swap(false, true, Ordering::Relaxed) == false {
             loop {

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -27,14 +27,14 @@ pub trait Listener<COMP: Component> {
     fn attach(&mut self, element: &Element, scope: Scope<COMP>) -> EventListenerHandle;
 }
 
-impl<COMP: Component> fmt::Debug for Listener<COMP> {
+impl<COMP: Component> fmt::Debug for dyn Listener<COMP> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Listener {{ kind: {} }}", self.kind())
     }
 }
 
 /// A list of event listeners.
-type Listeners<COMP> = Vec<Box<Listener<COMP>>>;
+type Listeners<COMP> = Vec<Box<dyn Listener<COMP>>>;
 
 /// A map of attributes.
 type Attributes = HashMap<String, String>;

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -14,7 +14,7 @@ use Hidden;
 type AnyProps = (TypeId, *mut Hidden);
 
 /// The method generates an instance of a (child) component.
-type Generator = FnMut(Element, Option<Node>, AnyProps);
+type Generator = dyn FnMut(Element, Option<Node>, AnyProps);
 
 /// A reference to unknown activator which will be attached later with a generator function.
 type LazyActivator<COMP> = Rc<RefCell<Option<Scope<COMP>>>>;
@@ -24,10 +24,10 @@ pub struct VComp<COMP: Component> {
     type_id: TypeId,
     cell: NodeCell,
     props: Option<(TypeId, *mut Hidden)>,
-    blind_sender: Box<FnMut(AnyProps)>,
+    blind_sender: Box<dyn FnMut(AnyProps)>,
     generator: Box<Generator>,
     activators: Vec<LazyActivator<COMP>>,
-    destroyer: Box<Fn()>,
+    destroyer: Box<dyn Fn()>,
     _parent: PhantomData<COMP>,
 }
 

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -101,8 +101,8 @@ impl<COMP: Component, T: ToString> From<T> for VNode<COMP> {
     }
 }
 
-impl<'a, COMP: Component> From<&'a Renderable<COMP>> for VNode<COMP> {
-    fn from(value: &'a Renderable<COMP>) -> Self {
+impl<'a, COMP: Component> From<&'a dyn Renderable<COMP>> for VNode<COMP> {
+    fn from(value: &'a dyn Renderable<COMP>) -> Self {
         value.view()
     }
 }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -121,7 +121,7 @@ impl<COMP: Component> VTag<COMP> {
     /// Adds new listener to the node.
     /// It's boxed because we want to keep it in a single list.
     /// Lates `Listener::attach` called to attach actual listener to a DOM node.
-    pub fn add_listener(&mut self, listener: Box<Listener<COMP>>) {
+    pub fn add_listener(&mut self, listener: Box<dyn Listener<COMP>>) {
         self.listeners.push(listener);
     }
 


### PR DESCRIPTION
deny deprecated syntax in main code:
* anonymous parameters in fns in trait definitions
* trait objects without `dyn`

TODO: wait for the next stable rust release and deny `elided_lifetimes_in_paths`