### PR TITLE
SVG/XMLNS Proof of Concept

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 bincode = "1.0"
 anymap = "0.12"
 slab = "0.4"
-stdweb = "^0.4.9"
+stdweb = { git = "https://github.com/siler/stdweb.git" }
 toml = { version = "0.4", optional = true }
 serde_yaml = { version = "0.7", optional = true }
 rmp-serde = { version = "0.13.7", optional = true }


### PR DESCRIPTION
I've been playing around with yew a bit and am enjoying it so far, but I really wanted SVG support. This is a working POC I'm toying with at the moment. I wanted to put this up for discussion as there are others interested in yew correctly rendering SVGs: #328, #143.

It is implemented as a sort of final pass after packing the virtual DOM stack generated during html macro execution. The solution I applied is to intercept specific tag names (namely svg) and add a namespace to their VTag. Then, at the conclusion of processing the html macro, the configured namespaces are proliferated down the children graph (unless explicitly overridden by a deeper explicit namespace being configured - which isn't currently possible). Finally, when apply is called, if the VTag has a namespace then create_element_ns will be called instead of create_element. Note that this change is contingent on koute/stdweb#271 or something like it being accepted.

Anywho, points for discussion:

- Is it appropriate to implicitly change the namespace of elements beneath an element like svg? This is how it works in HTML via the xmlns attribute, but we aren't bound by that.
  - If not, how will syntactic access to namespaces be provided?
  - If so, how can children reference other namespaces?
- Should namespaces be aliased at a top level node (if necessary) and elements referenced via prefix e.g. < .. xmlns:svg=".."><s:svg> .. ?

I also tidied up the grammar/formatting a bit in areas I touched. If that is an issue, those changes can be reverted.