### PR TITLE
deny `elided_lifetimes_in_paths`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,7 +56,7 @@
 //! ```
 //!
 
-#![deny(missing_docs, bare_trait_objects, anonymous_parameters)]
+#![deny(missing_docs, bare_trait_objects, anonymous_parameters, elided_lifetimes_in_paths)]
 #![recursion_limit = "512"]
 
 #[macro_use]

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -28,7 +28,7 @@ pub trait Listener<COMP: Component> {
 }
 
 impl<COMP: Component> fmt::Debug for dyn Listener<COMP> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "Listener {{ kind: {} }}", self.kind())
     }
 }

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -108,7 +108,7 @@ impl<'a, COMP: Component> From<&'a dyn Renderable<COMP>> for VNode<COMP> {
 }
 
 impl<COMP: Component> fmt::Debug for VNode<COMP> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             VNode::VTag(ref vtag) => vtag.fmt(f),
             VNode::VText(ref vtext) => vtext.fmt(f),

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -456,7 +456,7 @@ impl<COMP: Component> VDiff for VTag<COMP> {
 }
 
 impl<COMP: Component> fmt::Debug for VTag<COMP> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "VTag {{ tag: {} }}", self.tag)
     }
 }

--- a/src/virtual_dom/vtext.rs
+++ b/src/virtual_dom/vtext.rs
@@ -93,7 +93,7 @@ impl<COMP: Component> VDiff for VText<COMP> {
 }
 
 impl<COMP: Component> fmt::Debug for VText<COMP> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "VText {{ text: {} }}", self.text)
     }
 }


### PR DESCRIPTION
this *should* build now whit the new rust release