### PR TITLE
fix: multi-thread example: link needs to be mutable

### DIFF
--- a/examples/multi_thread/src/lib.rs
+++ b/examples/multi_thread/src/lib.rs
@@ -29,7 +29,7 @@ impl Component for Model {
     type Message = Msg;
     type Properties = ();
 
-    fn create(_: Self::Properties, link: ComponentLink<Self>) -> Self {
+    fn create(_: Self::Properties, mut link: ComponentLink<Self>) -> Self {
         let callback = link.send_back(|_| Msg::DataReceived);
         let worker = native_worker::Worker::bridge(callback);
 


### PR DESCRIPTION
link needs to be mutable for it to compile due to `send_back` requiring a mutable borrow