### PR TITLE
Select component

### DIFF
--- a/examples/showcase/src/main.rs
+++ b/examples/showcase/src/main.rs
@@ -25,7 +25,7 @@ extern crate todomvc;
 extern crate two_apps;
 
 use strum::IntoEnumIterator;
-use std::str::FromStr;
+use yew::components::Select;
 use yew::prelude::*;
 use counter::Model as Counter;
 use crm::Model as Crm;
@@ -43,9 +43,8 @@ use timer::Model as Timer;
 use todomvc::Model as Todomvc;
 use two_apps::Model as TwoApps;
 
-#[derive(Debug, Display, EnumString, EnumIter)]
+#[derive(Clone, Debug, Display, EnumString, EnumIter, PartialEq)]
 enum Scene {
-    NotSelected,
     Counter,
     Crm,
     CustomComponents,
@@ -63,57 +62,47 @@ enum Scene {
     TwoApps,
 }
 
+struct Model {
+    scene: Option<Scene>,
+}
+
 enum Msg {
     SwitchTo(Scene),
 }
 
-impl Component for Scene {
+impl Component for Model {
     type Message = Msg;
     type Properties = ();
 
     fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
-        Scene::NotSelected
+        Self {
+            scene: None,
+        }
     }
 
     fn update(&mut self, msg: Self::Message) -> ShouldRender {
         match msg {
             Msg::SwitchTo(scene) => {
-                *self = scene;
+                self.scene = Some(scene);
                 true
             }
         }
     }
 }
 
-impl Renderable<Scene> for Scene {
+impl Renderable<Model> for Model {
     fn view(&self) -> Html<Self> {
-        let _options = Scene::iter().map(|scene| {
-            html! {
-                <option value={ scene.to_string() }, > { scene.to_string() } </option>
-            }
-        });
-
         html! {
             <div id="fullscreen",>
                 <div id="left_pane",>
                     <h2>{ "Yew showcase" }</h2>
-                    <select size="20", value={Scene::NotSelected.to_string()},
-                        onchange=|cd| {
-                            let scene = match cd {
-                                ChangeData::Select(se) => se.value().unwrap(),
-                                _ => unreachable!()
-                            };
-                            match Scene::from_str(&scene) {
-                                Ok(scene) => Msg::SwitchTo(scene),
-                                _ => unreachable!(),
-                            }
-                        }
-                    , >
-                        { for _options }
-                    </select>
+                    <Select<Scene>:
+                        selected=self.scene.clone(),
+                        options=Scene::iter().collect::<Vec<_>>(),
+                        onchange=Msg::SwitchTo,
+                        />
                 </div>
                 <div id="right_pane",>
-                    <h2>{ self.to_string() }</h2>
                     { self.view_scene() }
                 </div>
             </div>
@@ -121,88 +110,89 @@ impl Renderable<Scene> for Scene {
     }
 }
 
-impl Scene {
+impl Model {
     fn view_scene(&self) -> Html<Self> {
-        match *self {
-            Scene::NotSelected => {
-                html! {
-                    <p>{ "Select the scene, please." }</p>
+        if let Some(scene) = self.scene.as_ref() {
+            match scene {
+                Scene::Counter => {
+                    html! {
+                        <Counter: />
+                    }
+                }
+                Scene::Crm => {
+                    html! {
+                        <Crm: />
+                    }
+                }
+                Scene::CustomComponents => {
+                    html! {
+                        <CustomComponents: />
+                    }
+                }
+                Scene::Dashboard => {
+                    html! {
+                        <Dashboard: />
+                    }
+                }
+                Scene::Fragments => {
+                    html! {
+                        <Fragments: />
+                    }
+                }
+                Scene::GameOfLife => {
+                    html! {
+                        <GameOfLife: />
+                    }
+                }
+                Scene::InnerHtml => {
+                    html! {
+                        <InnerHtml: />
+                    }
+                }
+                Scene::LargeTable => {
+                    html! {
+                        <LargeTable: />
+                    }
+                }
+                Scene::MountPoint => {
+                    html! {
+                        <MountPoint: />
+                    }
+                }
+                Scene::NpmAndRest => {
+                    html! {
+                        <NpmAndRest: />
+                    }
+                }
+                Scene::Routing => {
+                    html! {
+                        <Routing: />
+                    }
+                }
+                Scene::Textarea => {
+                    html! {
+                        <Textarea: />
+                    }
+                }
+                Scene::Timer => {
+                    html! {
+                        <Timer: />
+                    }
+                }
+                Scene::Todomvc => {
+                    html! {
+                        <Todomvc: />
+                    }
+                }
+                Scene::TwoApps => {
+                    html! {
+                        <TwoApps: />
+                    }
                 }
             }
-            Scene::Counter => {
-                html! {
-                    <Counter: />
-                }
-            }
-            Scene::Crm => {
-                html! {
-                    <Crm: />
-                }
-            }
-            Scene::CustomComponents => {
-                html! {
-                    <CustomComponents: />
-                }
-            }
-            Scene::Dashboard => {
-                html! {
-                    <Dashboard: />
-                }
-            }
-            Scene::Fragments => {
-                html! {
-                    <Fragments: />
-                }
-            }
-            Scene::GameOfLife => {
-                html! {
-                    <GameOfLife: />
-                }
-            }
-            Scene::InnerHtml => {
-                html! {
-                    <InnerHtml: />
-                }
-            }
-            Scene::LargeTable => {
-                html! {
-                    <LargeTable: />
-                }
-            }
-            Scene::MountPoint => {
-                html! {
-                    <MountPoint: />
-                }
-            }
-            Scene::NpmAndRest => {
-                html! {
-                    <NpmAndRest: />
-                }
-            }
-            Scene::Routing => {
-                html! {
-                    <Routing: />
-                }
-            }
-            Scene::Textarea => {
-                html! {
-                    <Textarea: />
-                }
-            }
-            Scene::Timer => {
-                html! {
-                    <Timer: />
-                }
-            }
-            Scene::Todomvc => {
-                html! {
-                    <Todomvc: />
-                }
-            }
-            Scene::TwoApps => {
-                html! {
-                    <TwoApps: />
-                }
+        } else {
+            html! {
+                <p>{ "Select the scene, please." }</p>
             }
         }
     }
@@ -213,7 +203,7 @@ fn main() {
     trace!("Initializing yew...");
     yew::initialize();
     trace!("Creating an application instance...");
-    let app: App<Scene> = App::new();
+    let app: App<Model> = App::new();
     trace!("Mount the App to the body of the page...");
     app.mount_to_body();
     trace!("Run");

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,0 +1,6 @@
+//! This module contains useful components.
+//! At this moment it includes typed `Select` only.
+
+pub mod select;
+
+pub use self::select::Select;

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -1,0 +1,121 @@
+//! This module contains implementation of `Select` component.
+//! You can use it instead `<select>` tag, because the component
+//! helps you to track selected value in an original type. Example:
+//!
+//! ```
+//! enum Scene {
+//!     First,
+//!     Second,
+//! }
+//!
+//! fn view() -> Html<Model> {
+//!     let scenes = vec![Scene::First, Scene::Second];
+//!     html! {
+//!         <Select<Scenes>: options=scenes, />
+//!     }
+//! }
+
+use callback::Callback;
+use html::{ChangeData, Component, ComponentLink, Html, Renderable, ShouldRender};
+
+/// `Select` component.
+pub struct Select<T> {
+    props: Props<T>,
+}
+
+/// Internal message of the component.
+pub enum Msg {
+    /// This message indicates the option with id selected.
+    Selected(Option<usize>),
+}
+
+/// Properties of `Select` component.
+#[derive(PartialEq, Clone)]
+pub struct Props<T> {
+    /// Initially selected value.
+    pub selected: Option<T>,
+    /// Disabled the component's selector.
+    pub disabled: bool,
+    /// Options are available to choose.
+    pub options: Vec<T>,
+    /// Callback to handle changes.
+    pub onchange: Option<Callback<T>>,
+}
+
+impl<T> Default for Props<T> {
+    fn default() -> Self {
+        Props {
+            selected: None,
+            disabled: false,
+            options: Vec::new(),
+            onchange: None,
+        }
+    }
+}
+
+impl<T> Component for Select<T>
+where
+    T: PartialEq + Clone + 'static,
+{
+    type Message = Msg;
+    type Properties = Props<T>;
+
+    fn create(props: Self::Properties, _: ComponentLink<Self>) -> Self {
+        Self { props }
+    }
+
+    fn update(&mut self, msg: Self::Message) -> ShouldRender {
+        match msg {
+            Msg::Selected(value) => {
+                if let Some(idx) = value {
+                    if let Some(ref mut callback) = self.props.onchange {
+                        let item = self.props.options.get(idx - 1).cloned();
+                        if let Some(value) = item {
+                            callback.emit(value);
+                        }
+                    }
+                }
+            }
+        }
+        true
+    }
+
+    fn change(&mut self, props: Self::Properties) -> ShouldRender {
+        self.props = props;
+        true
+    }
+}
+
+impl<T> Renderable<Select<T>> for Select<T>
+where
+    T: ToString + PartialEq + Clone + 'static,
+{
+    fn view(&self) -> Html<Self> {
+        let selected = self.props.selected.as_ref();
+        let view_option = |value: &T| {
+            let flag = selected == Some(value);
+            html! {
+                <option selected=flag,>{ value.to_string() }</option>
+            }
+        };
+        html! {
+            <select disabled=self.props.disabled,
+                    onchange=|event| {
+                        match event {
+                            ChangeData::Select(elem) => {
+                                let value = elem.selected_index().map(|x| x as usize);
+                                Msg::Selected(value)
+                            }
+                            _ => {
+                                unreachable!();
+                            }
+                        }
+                    },>
+                <option disabled=true,
+                        selected=selected.is_none(),
+                        >{ "↪" }</option>
+                { for self.props.options.iter().map(view_option) }
+            </select>
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,6 +93,7 @@ pub mod virtual_dom;
 pub mod callback;
 pub mod scheduler;
 pub mod agent;
+pub mod components;
 
 use std::rc::Rc;
 use std::cell::RefCell;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -79,6 +79,12 @@ macro_rules! html_impl {
         }
         html_impl! { @vtag $stack ($($tail)*) }
     };
+    (@vtag $stack:ident (selected = $kind:expr, $($tail:tt)*)) => {
+        if $kind {
+            $crate::macros::add_attribute(&mut $stack, "selected", "selected");
+        }
+        html_impl! { @vtag $stack ($($tail)*) }
+    };
     // Events:
     (@vtag $stack:ident (onclick = | $var:pat | $handler:expr, $($tail:tt)*)) => {
         html_impl! { @vtag $stack ((onclick) = move | $var: $crate::prelude::ClickEvent | $handler, $($tail)*) }


### PR DESCRIPTION
This PR includes yew's implementation of `Select` component, like: https://github.com/JedWatson/react-select.

You can use it in this way (see `showcase` example):

```rust
#[derive(Clone, Debug, Display, EnumString, EnumIter, PartialEq)]
enum Scene {
    Scene1,
    // ...
    Scene42,
}

impl Renderable<Model> for Model {
    fn view(&self) -> Html<Self> {
        html! {
            <div id="fullscreen",>
                <div id="left_pane",>
                    <h2>{ "Yew showcase" }</h2>

                    <Select<Scene>:
                        selected=self.scene.clone(),
                        options=Scene::iter().collect::<Vec<_>>(),
                        onchange=Msg::SwitchTo,
                        />

                </div>
                <div id="right_pane",>
                    { self.view_scene() }
                </div>
            </div>
        }
    }
}

```