### PR TITLE
Fix the bug when a fragment replaces a single node

### DIFF
--- a/src/virtual_dom/vlist.rs
+++ b/src/virtual_dom/vlist.rs
@@ -49,9 +49,9 @@ impl<COMP: Component> VDiff for VList<COMP> {
                     vlist.childs.drain(..).map(Some).collect::<Vec<_>>()
                 }
                 Some(mut vnode) => {
-                    let node = vnode.detach(parent);
-                    precursor = node;
-                    Vec::new()
+                    // Use the current node as a single fragment list
+                    // and let the `apply` of `VNode` to handle it.
+                    vec![Some(vnode)]
                 }
                 None => Vec::new(),
             }

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -363,7 +363,9 @@ impl<COMP: Component> VDiff for VTag<COMP> {
                     let node = vnode.detach(parent);
                     (Reform::Before(node), None)
                 }
-                None => (Reform::Before(None), None),
+                None => {
+                    (Reform::Before(None), None)
+                },
             }
         };
 


### PR DESCRIPTION
This PR fixes a bug with the case:

```rust
if expanded {
    html! {
        <li class="accordion-item", />
    }
} else {
    html! {
        <>
            <li class="accordion-item", />
            <div class="accordion-item-content",>{ "Content" }</div>
        </>
    }
}
```
Before this fix the framework removes the current item and puts a fragment after the next (not the current) item.