### PR TITLE
Simplify README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,12 +411,6 @@ yew = { git = "https://github.com/DenisKolodin/yew", features = ["toml", "yaml",
 
 Clone or download this repository.
 
-Add necessary targets to your compiler:
-
-    $ rustup target add wasm32-unknown-unknown
-
-> We recommend to use `wasm32-unknown-unknown` target where possible, but some third-party crates can be compiled with `wasm32-unknown-emscripten` target only.
-
 To build this project you need to have [cargo-web] installed:
 
     $ cargo install cargo-web
@@ -425,7 +419,7 @@ To build this project you need to have [cargo-web] installed:
 
 ### Build
 
-    $ cargo web build --target=wasm32-unknown-unknown
+    $ cargo web build
 
 ### Running Tests
 
@@ -445,10 +439,7 @@ To run an optimised build instead of a debug build use:
 
     $ cargo web start --release
 
-**Note**: By default, `cargo-web` will use Emscripten to generate asm.js. You can also
-compile to WebAssembly if you add either `--target=wasm32-unknown-emscripten` or
-`--target=wasm32-unknown-unknown`, where the first one will use Emscripten and
-the second one will use Rust's native WebAssembly backend (Rust nightly only!).
+This will use the `wasm32-unknown-unknown` target by default, which is Rust's native WebAssembly target. The Emscripten-based `wasm32-unknown-emscripten` and `asmjs-unknown-emscripten` targets are also supported if you tell the `cargo-web` to build for them using the `--target` parameter.
 
 [counter]: examples/counter
 [crm]: examples/crm


### PR DESCRIPTION
1. `cargo-web` will automatically install the relevant target through `rustup` for the user.
2. The `wasm32-unknown-unknown` target is the default now on the newest version of `cargo-web`, and is officially supported on stable.