### PR TITLE
expression as a tag name

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -43,6 +43,12 @@ macro_rules! html_impl {
         $crate::macros::child_to_parent(&mut $stack, None);
         html_impl! { $stack ($($tail)*) }
     };
+    // Start of opening tag with expression as tag name
+    ($stack:ident (< { $starttag:expr } $($tail:tt)*)) => {
+        let vtag = $crate::virtual_dom::VTag::new($starttag);
+        $stack.push(vtag.into());
+        html_impl! { @vtag $stack ($($tail)*) }
+    };
     // Start of opening tag
     ($stack:ident (< $starttag:ident $($tail:tt)*)) => {
         let vtag = $crate::virtual_dom::VTag::new(stringify!($starttag));
@@ -205,6 +211,11 @@ macro_rules! html_impl {
         let attr = vec![$(stringify!($attr).to_string()),+].join("-");
         $crate::macros::add_attribute(&mut $stack, &attr, $val);
         html_impl! { @vtag $stack ($($tail)*) }
+    };
+    // Traditional tag closing with expression as tag name
+    ($stack:ident (< / { $endtag:expr } > $($tail:tt)*)) => {
+        $crate::macros::child_to_parent(&mut $stack, Some($endtag));
+        html_impl! { $stack ($($tail)*) }
     };
     // Traditional tag closing
     ($stack:ident (< / $endtag:ident > $($tail:tt)*)) => {


### PR DESCRIPTION
Hi,

I need to choose a tag name in runtime, eg.:
```rust
let html_tag = "p";
html! {
    <{html_tag}>{{ "text" }}</{html_tag}>
}
```

And these macros should also work as a workaround for non-standard tags (see #193), eg:
```
<{"menu-item"}></{"menu-item"}>
```

I didn't find any tests for html creation (?), but my project, based on yew with 5k LoC, works fine with these changes. 