### PR TITLE
Fix #458 so that Yew compiles.

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,6 +4,7 @@
 use html::Component;
 use virtual_dom::{Listener, VNode};
 
+/// The html! entrypoint and this implementation had to be separated to prevent infinite recursion.
 #[macro_export]
 macro_rules! html_impl {
     ($stack:ident (< > $($tail:tt)*)) => {
@@ -273,7 +274,7 @@ macro_rules! html_impl {
     };
 }
 
-// This entrypoint and implementation had separated to prevent infinite recursion.
+/// This macro implements JSX-like templates.
 #[macro_export]
 macro_rules! html {
     ($($tail:tt)*) => {{


### PR DESCRIPTION
After a compiler upgrade, the #[deny(missing_docs)] directive started (correctly) causing the compilation to stop with an error message saying that documentation is required for these 2 macros. I guessed at a short version of what those comments might be, and adding the comments allows Yew to compile.