### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
 # Changelog
 
-## 0.5 - unreleased
+## 0.6 - unreleased
+
+### Breaking changes
+
+### New features
+
+### Bug fixes
+
+## 0.5 - Released 2019-02-01
 
 ### Breaking changes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "yew"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Denis Kolodin <deniskolodin@gmail.com>"]
 repository = "https://github.com/DenisKolodin/yew"
 homepage = "https://github.com/DenisKolodin/yew"


### PR DESCRIPTION
Okay, I've revised the current state and decided to release all current changes as **0.5.0** and start a new branch to make some changes with a structure of modules (for Rust 2018). I want to prepare the project to upcoming changes I want to do.