### PR TITLE
Fix script src of examples

### DIFF
--- a/examples/js_callback/static/index.html
+++ b/examples/js_callback/static/index.html
@@ -5,7 +5,7 @@
         <title>(Asynchronous) callback from JavaScript</title>
     </head>
     <body>
-        <script src="js/app.js"></script>
+        <script src="/js_callback.js"></script>
         <script src="get-payload-script.js"></script>
     </body>
 </html>

--- a/examples/multi_thread/static/index.html
+++ b/examples/multi_thread/static/index.html
@@ -5,7 +5,7 @@
         <title>Yew • Multi-Thread</title>
     </head>
     <body>
-        <script src="js/app.js"></script>
+        <script src="/main.js"></script>
     </body>
 </html>
 

--- a/examples/npm_and_rest/static/index.html
+++ b/examples/npm_and_rest/static/index.html
@@ -6,7 +6,7 @@
         <script type="text/javascript" src="https://unpkg.com/ccxt"></script>
     </head>
     <body>
-        <script src="js/app.js"></script>
+        <script src="/npm_and_rest.js"></script>
     </body>
 </html>
 

--- a/examples/two_apps/static/index.html
+++ b/examples/two_apps/static/index.html
@@ -8,7 +8,7 @@
     <body>
         <div class="first-app"></div>
         <div class="second-app"></div>
-        <script src="js/app.js"></script>
+        <script src="/two_apps.js"></script>
     </body>
 </html>
 


### PR DESCRIPTION
Hi! I just found out that src path is deprecated.

```
!!!!!!!!!!!!!!!!!!!!!
WARNING: `/js/app.js` is deprecated; you should update your HTML file to use `/foo.js` instead!
!!!!!!!!!!!!!!!!!!!!!
```