### PR TITLE
Allow to use value attribute for all tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@
 
 ### Bug fixes
 
+- It was impossible to set `value` attribute for any tag instead of `option`, because it used
+  inner value of `VTag` to keep the value for `input` element. Now `value` attribute works
+  for `options`, `progress` tags, etc.
+
 ## 0.5 - Released 2019-02-01
 
 ### Breaking changes

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -311,13 +311,15 @@ pub fn unpack<COMP: Component>(mut stack: Stack<COMP>) -> VNode<COMP> {
     stack.pop().expect("no html elements in the stack")
 }
 
+/// This method uses `value` attribute of macro to set a value of `input` element
+/// or set that attribute as is for other elements like: `option`, `progress`, etc.
 #[doc(hidden)]
 pub fn set_value_or_attribute<COMP: Component, T: ToString>(stack: &mut Stack<COMP>, value: T) {
     if let Some(&mut VNode::VTag(ref mut vtag)) = stack.last_mut() {
-        if vtag.tag().eq_ignore_ascii_case("option") {
-            vtag.add_attribute("value", &value)
-        } else {
+        if vtag.tag().eq_ignore_ascii_case("input") {
             vtag.set_value(&value)
+        } else {
+            vtag.add_attribute("value", &value)
         }
     } else {
         panic!("no tag to set value: {}", value.to_string());


### PR DESCRIPTION
It was allowed for `option` before.