### PR TITLE
Update to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 keywords = ["web", "asmjs", "webasm", "javascript"]
 categories = ["gui", "web-programming"]
 description = "A framework for making client-side single-page apps"
+edition = "2018"
 
 [dependencies]
 failure = "0.1"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -8,8 +8,8 @@ use bincode;
 use anymap::{AnyMap, Entry};
 use slab::Slab;
 use stdweb::Value;
-use scheduler::{Runnable, Shared, scheduler};
-use callback::Callback;
+use crate::scheduler::{Runnable, Shared, scheduler};
+use crate::callback::Callback;
 
 #[derive(Serialize, Deserialize)]
 enum ToWorker<T> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -2,7 +2,7 @@
 //! a component in an isolated scope.
 
 use stdweb::web::{document, Element, INode, IParentNode};
-use html::{Scope, Component, Renderable};
+use crate::html::{Scope, Component, Renderable};
 
 /// An application instance.
 pub struct App<COMP: Component> {

--- a/src/components/select.rs
+++ b/src/components/select.rs
@@ -15,8 +15,8 @@
 //!     }
 //! }
 
-use callback::Callback;
-use html::{ChangeData, Component, ComponentLink, Html, Renderable, ShouldRender};
+use crate::callback::Callback;
+use crate::html::{ChangeData, Component, ComponentLink, Html, Renderable, ShouldRender};
 
 /// `Select` component.
 pub struct Select<T> {

--- a/src/html.rs
+++ b/src/html.rs
@@ -7,9 +7,9 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use stdweb::web::{Element, EventListenerHandle, FileList, INode, Node};
 use stdweb::web::html_element::SelectElement;
-use virtual_dom::{Listener, VDiff, VNode};
-use callback::Callback;
-use scheduler::{Runnable, Shared, scheduler};
+use crate::virtual_dom::{Listener, VDiff, VNode};
+use crate::callback::Callback;
+use crate::scheduler::{Runnable, Shared, scheduler};
 
 /// This type indicates that component should be rendered again.
 pub type ShouldRender = bool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ where
 
 /// The module that contains all events available in the framework.
 pub mod events {
-    pub use html::{
+    pub use crate::html::{
         ChangeData,
         InputData,
     };
@@ -173,7 +173,7 @@ pub mod events {
 /// use yew::prelude::*;
 /// ```
 pub mod prelude {
-    pub use html::{
+    pub use crate::html::{
         Component,
         ComponentLink,
         Href,
@@ -182,21 +182,21 @@ pub mod prelude {
         ShouldRender,
     };
 
-    pub use app::App;
+    pub use crate::app::App;
 
-    pub use callback::Callback;
+    pub use crate::callback::Callback;
 
-    pub use agent::{
+    pub use crate::agent::{
         Bridge,
         Bridged,
         Threaded,
     };
 
-    pub use events::*;
+    pub use crate::events::*;
 
     /// Prelude module for creating worker.
     pub mod worker {
-        pub use agent::{
+        pub use crate::agent::{
             Agent,
             AgentLink,
             Bridge,

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,8 +1,8 @@
 //! This module contains macros which implements `html!` macro
 //! and JSX-like templates.
 
-use html::Component;
-use virtual_dom::{Listener, VNode};
+use crate::html::Component;
+use crate::virtual_dom::{Listener, VNode};
 
 #[doc(hidden)]
 #[macro_export]

--- a/src/services/fetch.rs
+++ b/src/services/fetch.rs
@@ -8,8 +8,8 @@ use stdweb::unstable::{TryInto, TryFrom};
 use stdweb::serde::Serde;
 
 use super::Task;
-use format::{Format, Text, Binary};
-use callback::Callback;
+use crate::format::{Format, Text, Binary};
+use crate::callback::Callback;
 
 pub use http::{HeaderMap, Method, Request, Response, StatusCode, Uri};
 

--- a/src/services/interval.rs
+++ b/src/services/interval.rs
@@ -2,7 +2,7 @@
 //! periodic sending messages to a loop.
 
 use super::{to_ms, Task};
-use callback::Callback;
+use crate::callback::Callback;
 use std::time::Duration;
 use stdweb::Value;
 

--- a/src/services/reader.rs
+++ b/src/services/reader.rs
@@ -13,7 +13,7 @@ use stdweb::web::event::{
     LoadEndEvent,
 };
 use stdweb::unstable::TryInto;
-use callback::Callback;
+use crate::callback::Callback;
 use super::Task;
 
 /// Struct that represents data of a file.

--- a/src/services/render.rs
+++ b/src/services/render.rs
@@ -3,8 +3,8 @@
 
 use stdweb::Value;
 use stdweb::unstable::TryInto;
-use services::Task;
-use callback::Callback;
+use crate::services::Task;
+use crate::callback::Callback;
 
 /// A handle to cancel a render task.
 #[must_use]

--- a/src/services/storage.rs
+++ b/src/services/storage.rs
@@ -1,7 +1,7 @@
 //! This module contains the implementation of a service to
 //! use local and session storage of a browser.
 
-use format::Text;
+use crate::format::Text;
 use stdweb::web::{window, Storage};
 
 /// Represents errors of a storage.

--- a/src/services/timeout.rs
+++ b/src/services/timeout.rs
@@ -2,7 +2,7 @@
 //! send a messages when timeout elapsed.
 
 use super::{to_ms, Task};
-use callback::Callback;
+use crate::callback::Callback;
 use std::time::Duration;
 use stdweb::Value;
 

--- a/src/services/websocket.rs
+++ b/src/services/websocket.rs
@@ -14,8 +14,8 @@ use stdweb::web::event::{
     SocketErrorEvent,
 };
 use stdweb::traits::IMessageEvent;
-use format::{Text, Binary};
-use callback::Callback;
+use crate::format::{Text, Binary};
+use crate::callback::Callback;
 use super::Task;
 
 #[derive(Debug)]

--- a/src/virtual_dom/mod.rs
+++ b/src/virtual_dom/mod.rs
@@ -15,7 +15,7 @@ pub use self::vlist::VList;
 pub use self::vnode::VNode;
 pub use self::vtag::VTag;
 pub use self::vtext::VText;
-use html::{Component, Scope};
+use crate::html::{Component, Scope};
 
 /// `Listener` trait is an universal implementation of an event listener
 /// which helps to bind Rust-listener to JS-listener (DOM).

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -6,8 +6,8 @@ use std::marker::PhantomData;
 use std::rc::Rc;
 use stdweb::unstable::TryInto;
 use stdweb::web::{document, Element, INode, Node};
-use html::{Component, ComponentUpdate, Scope, NodeCell, Renderable};
-use callback::Callback;
+use crate::html::{Component, ComponentUpdate, Scope, NodeCell, Renderable};
+use crate::callback::Callback;
 use super::{Reform, VDiff, VNode};
 
 struct Hidden;

--- a/src/virtual_dom/vlist.rs
+++ b/src/virtual_dom/vlist.rs
@@ -1,6 +1,6 @@
 //! This module contains fragments implementation.
 use super::{VDiff, VNode, VText};
-use html::{Component, Scope};
+use crate::html::{Component, Scope};
 use stdweb::web::Node;
 
 /// This struct represents a fragment of the Virtual DOM tree.

--- a/src/virtual_dom/vnode.rs
+++ b/src/virtual_dom/vnode.rs
@@ -1,7 +1,7 @@
 //! This module contains the implementation of abstract virtual node.
 
 use super::{VComp, VDiff, VList, VTag, VText};
-use html::{Component, Renderable, Scope};
+use crate::html::{Component, Renderable, Scope};
 use std::cmp::PartialEq;
 use std::fmt;
 use stdweb::web::{INode, Node};

--- a/src/virtual_dom/vtag.rs
+++ b/src/virtual_dom/vtag.rs
@@ -8,7 +8,7 @@ use stdweb::web::html_element::TextAreaElement;
 use stdweb::unstable::TryFrom;
 use stdweb::web::html_element::InputElement;
 use stdweb::web::{document, Element, EventListenerHandle, IElement, INode, Node};
-use html::{Component, Scope};
+use crate::html::{Component, Scope};
 use super::{Attributes, Classes, Listener, Listeners, Patch, Reform, VDiff, VNode};
 
 /// A type for a virtual

--- a/src/virtual_dom/vtext.rs
+++ b/src/virtual_dom/vtext.rs
@@ -4,7 +4,7 @@ use std::cmp::PartialEq;
 use std::fmt;
 use std::marker::PhantomData;
 use stdweb::web::{document, INode, Node, TextNode};
-use html::{Component, Scope};
+use crate::html::{Component, Scope};
 use super::{Reform, VDiff, VNode};
 
 /// A type for a virtual


### PR DESCRIPTION
This PR includes the minimal amount of changes to use 2018 edition Rust. All tests are passing.

There are additional changes that could be made (removing all `extern` declarations for example) but I left those alone to keep this PR as small as possible.