### PR TITLE
Support building wasm targets without cargo-web using wasm-bindgen

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,0 +1,2 @@
+[target.'cfg(all(target_arch = "wasm32", not(cargo_web)))']
+runner = 'wasm-bindgen-test-runner'

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,13 @@ matrix:
   allow_failures:
     - rust: nightly
 
-script:
+install:
   - nvm install 9
+  - rustup target add wasm32-unknown-unknown
+  - cargo install wasm-bindgen-cli --force
+  - curl --retry 5 -LO https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
+  - unzip chromedriver_linux64.zip
   - ./ci/install_cargo_web.sh
-  - ./ci/run_tests.sh
+
+script:
+  - CHROMEDRIVER=$(pwd)/chromedriver ./ci/run_tests.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ serde_json = "1.0"
 bincode = "=1.0.1"
 anymap = "0.12"
 slab = "0.4"
-stdweb = "^0.4.14"
+stdweb = "^0.4.16"
 toml = { version = "0.4", optional = true }
 serde_yaml = { version = "0.8.3", optional = true }
 rmp-serde = { version = "0.13.7", optional = true }
@@ -29,8 +29,14 @@ serde_cbor = { version = "0.9.0", optional = true }
 yew-macro = { path = "crates/macro", optional = true }
 yew-shared = { path = "crates/shared" }
 
+[target.'cfg(all(target_arch = "wasm32", not(cargo_web)))'.dependencies]
+wasm-bindgen = "0.2"
+
 [dev-dependencies]
 serde_derive = "1"
+
+[target.'cfg(all(target_arch = "wasm32", not(cargo_web)))'.dev-dependencies]
+wasm-bindgen-test = "0.2"
 
 [features]
 default = []

--- a/README.md
+++ b/README.md
@@ -407,19 +407,30 @@ yew = { git = "https://github.com/DenisKolodin/yew", features = ["toml", "yaml",
 
 Clone or download this repository.
 
-To build this project you need to have [cargo-web] installed:
+### Install [cargo-web]
 
-    $ cargo install cargo-web
+This is an optional tool that simplifies deploying web applications:
+
+```bash
+cargo install cargo-web
+```
 
 > Add `--force` option to ensure you install the latest version.
 
 ### Build
 
-    $ cargo web build
+```bash
+cargo web build
+
+# without cargo-web, only the wasm32-unknown-unknown target is supported
+cargo build --target wasm32-unknown-unknown
+```
 
 ### Running Tests
 
-    $ ./ci/run_tests.sh
+```bash
+./ci/run_tests.sh
+```
 
 ### Running the examples
 
@@ -429,11 +440,15 @@ There are many examples that show how the framework works:
 
 To start an example enter its directory and start it with [cargo-web]:
 
-    $ cargo web start
+```bash
+cargo web start
+```
 
 To run an optimised build instead of a debug build use:
 
-    $ cargo web start --release
+```bash
+cargo web start --release
+```
 
 This will use the `wasm32-unknown-unknown` target by default, which is Rust's native WebAssembly target.
 The Emscripten-based `wasm32-unknown-emscripten` and `asmjs-unknown-emscripten` targets are also supported

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,9 @@
+use std::env;
+
+pub fn main() {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let cargo_web = env::var("COMPILING_UNDER_CARGO_WEB").unwrap_or_default();
+    if target_arch == "wasm32" && cargo_web != "1" {
+        println!("cargo:rustc-cfg=feature=\"wasm_bindgen_test\"");
+    }
+}

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -23,10 +23,8 @@ cargo web test --features web_test --target=asmjs-unknown-emscripten
 echo "Testing for wasm32-unknown-emscripten..."
 cargo web test --features web_test --target=wasm32-unknown-emscripten
 
-if [ "$IS_NIGHTLY" = "1" ]; then
-    echo "Testing for wasm32-unknown-unknown..."
-    cargo web test --nodejs --target=wasm32-unknown-unknown
-fi
+echo "Testing for wasm32-unknown-unknown..."
+cargo test --target=wasm32-unknown-unknown
 
 check_example() {
     echo "Checking example [$2]"
@@ -41,17 +39,6 @@ check_example() {
 check_all_examples() {
     echo "Checking examples on $1..."
     for EXAMPLE in $(pwd)/examples/showcase/sub/*; do
-        if [ "$1" == "wasm32-unknown-unknown" ]; then
-            # The counter example doesn't yet build here.
-            case $(basename $EXAMPLE) in
-                "counter")
-                continue
-                ;;
-                *)
-                ;;
-            esac
-        fi
-
         if [ -d "$EXAMPLE" ]; then
             check_example $1 $EXAMPLE
         fi
@@ -63,7 +50,4 @@ check_all_examples() {
 SHOWCASE=$(pwd)/examples/showcase
 check_example asmjs-unknown-emscripten $SHOWCASE
 check_example wasm32-unknown-emscripten $SHOWCASE
-
-if [ "$IS_NIGHTLY" = "1" ]; then
-    check_example wasm32-unknown-unknown $SHOWCASE
-fi
+check_example wasm32-unknown-unknown $SHOWCASE

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -11,7 +11,13 @@ serde = { version = "1.0", features = ["derive"] }
 bincode = "=1.0.1"
 anymap = "0.12"
 slab = "0.4"
-stdweb = "^0.4.14"
+stdweb = "^0.4.16"
+
+[target.'cfg(all(target_arch = "wasm32", not(cargo_web)))'.dependencies]
+wasm-bindgen = "0.2"
 
 [dev-dependencies]
 yew = { path = "../.." }
+
+[target.'cfg(all(target_arch = "wasm32", not(cargo_web)))'.dev-dependencies]
+wasm-bindgen-test = "0.2"

--- a/crates/shared/build.rs
+++ b/crates/shared/build.rs
@@ -1,0 +1,9 @@
+use std::env;
+
+pub fn main() {
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let cargo_web = env::var("COMPILING_UNDER_CARGO_WEB").unwrap_or_default();
+    if target_arch == "wasm32" && cargo_web != "1" {
+        println!("cargo:rustc-cfg=feature=\"wasm-bindgen-test\"");
+    }
+}

--- a/crates/shared/tests/vcomp_test.rs
+++ b/crates/shared/tests/vcomp_test.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "wasm-bindgen-test")]
+use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::virtual_dom::VNode;
 use yew::{html, Component, ComponentLink, Html, Renderable, ShouldRender};
+
+#[cfg(feature = "wasm-bindgen-test")]
+wasm_bindgen_test_configure!(run_in_browser);
 
 struct Comp;
 

--- a/crates/shared/tests/vlist_test.rs
+++ b/crates/shared/tests/vlist_test.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "wasm-bindgen-test")]
+use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::virtual_dom::VNode;
 use yew::{html, Component, ComponentLink, Html, Renderable, ShouldRender};
+
+#[cfg(feature = "wasm-bindgen-test")]
+wasm_bindgen_test_configure!(run_in_browser);
 
 struct Comp;
 

--- a/crates/shared/tests/vtag_test.rs
+++ b/crates/shared/tests/vtag_test.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "wasm-bindgen-test")]
+use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::virtual_dom::VNode;
 use yew::{html, Component, ComponentLink, Html, Renderable, ShouldRender};
+
+#[cfg(feature = "wasm-bindgen-test")]
+wasm_bindgen_test_configure!(run_in_browser);
 
 struct Comp;
 

--- a/crates/shared/tests/vtext_test.rs
+++ b/crates/shared/tests/vtext_test.rs
@@ -1,5 +1,10 @@
+#[cfg(feature = "wasm-bindgen-test")]
+use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::virtual_dom::VNode;
 use yew::{html, Component, ComponentLink, Html, Renderable, ShouldRender};
+
+#[cfg(feature = "wasm-bindgen-test")]
+wasm_bindgen_test_configure!(run_in_browser);
 
 struct Comp;
 

--- a/tests/format_test.rs
+++ b/tests/format_test.rs
@@ -1,8 +1,10 @@
 extern crate serde_derive;
 extern crate yew;
 
-use serde_derive::{Serialize, Deserialize};
-use yew::format::{Json, Text, Binary};
+use serde_derive::{Deserialize, Serialize};
+#[cfg(feature = "wasm-bindgen-test")]
+use wasm_bindgen_test::wasm_bindgen_test as test;
+use yew::format::{Binary, Json, Text};
 
 #[test]
 fn json_format() {


### PR DESCRIPTION
Fixes https://github.com/DenisKolodin/yew/issues/496

Details:
* Conditionally use `wasm-bindgen-test-runner` if cargo web is not used
* Bump `stdweb` version from `0.4.14` to `0.14.6` to get latest wasm-bindgen improvements
* Conditionally use dep `wasm-bindgen` if cargo web is not used
* Automatically apply `wasm_bindgen_test` feature if building for wasm targets without cargo web

I made this change in a way that still allows building with cargo-web. But it's now no longer required if targeting wasm