### PR TITLE
Add utils module with host function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,6 +77,7 @@ pub mod macros {
 pub mod components;
 pub mod format;
 pub mod services;
+pub mod utils;
 
 pub use yew_shared::*;
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,10 @@
+//! This module contains useful utils to get information about the current document.
+
+use failure::{err_msg, Error};
+use stdweb::web::document;
+
+/// Returns `host` for the current document. Useful to connect to a server that server the app.
+pub fn host() -> Result<String, Error> {
+    document().location().ok_or_else(|| err_msg("can't get location"))
+        .and_then(|l| l.host().map_err(Error::from))
+}


### PR DESCRIPTION
This PR adds `host` method useful to connect to a server that served assets with the app.

/cc @jstarry