### PR TITLE
Refactor component update

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -12,7 +12,7 @@ pub struct App<COMP: Component> {
 
 impl<COMP> App<COMP>
 where
-    COMP: Component + Renderable<COMP>,
+    COMP: Component<Properties = ()> + Renderable<COMP>,
 {
     /// Creates a new `App` with a component in a context.
     pub fn new() -> Self {
@@ -36,7 +36,7 @@ where
     /// will render the model to a virtual DOM tree.
     pub fn mount(self, element: Element) -> Scope<COMP> {
         clear_element(&element);
-        self.scope.mount_in_place(element, None, None, None)
+        self.scope.mount_in_place(element, None, None, ())
     }
 }
 

--- a/src/html.rs
+++ b/src/html.rs
@@ -44,7 +44,7 @@ pub trait Renderable<COMP: Component> {
     fn view(&self) -> Html<COMP>;
 }
 
-/// Update message for a `Components` instance. Used by scope sender.
+/// Updates for a `Components` instance. Used by scope sender.
 pub(crate) enum ComponentUpdate<COMP: Component> {
     /// Creating an instance of the component
     Create(ComponentLink<COMP>),
@@ -113,7 +113,7 @@ where
     pub(crate) fn send(&mut self, update: ComponentUpdate<COMP>) {
         let envelope = ComponentEnvelope {
             shared_component: self.shared_component.clone(),
-            message: Some(update),
+            update,
         };
         let runnable: Box<dyn Runnable> = Box::new(envelope);
         scheduler().put_and_try_run(runnable);
@@ -176,37 +176,33 @@ struct ComponentRunnable<COMP: Component> {
     destroyed: bool,
 }
 
-/// Wraps a component reference and a message to hide it under `Runnable` trait.
-/// It's necessary to schedule a processing of a message.
+/// Wraps a component reference and an update to hide it under `Runnable` trait.
+/// It's necessary to schedule a processing of an update.
 struct ComponentEnvelope<COMP>
 where
     COMP: Component,
 {
     shared_component: Shared<Option<ComponentRunnable<COMP>>>,
-    message: Option<ComponentUpdate<COMP>>,
+    update: ComponentUpdate<COMP>,
 }
 
 impl<COMP> Runnable for ComponentEnvelope<COMP>
 where
     COMP: Component + Renderable<COMP>,
 {
-    fn run(&mut self) {
+    fn run(self: Box<Self>) {
         let mut component = self.shared_component.borrow_mut();
         let this = component.as_mut().expect("shared component not set");
         if this.destroyed {
             return;
         }
         let mut should_update = false;
-        let upd = self
-            .message
-            .take()
-            .expect("component's envelope called twice");
         // This loop pops one item, because the following
         // updates could try to borrow the same cell
         // Important! Don't use `while let` here, because it
         // won't free the lock.
         let env = this.env.clone();
-        match upd {
+        match self.update {
             ComponentUpdate::Create(link) => {
                 let props = this.init_props.take().unwrap_or_default();
                 this.component = Some(COMP::create(props, link));

--- a/src/html.rs
+++ b/src/html.rs
@@ -8,8 +8,8 @@ use crate::scheduler::{scheduler, Runnable, Shared};
 use crate::virtual_dom::{Listener, VDiff, VNode};
 use log::debug;
 use std::cell::RefCell;
-use std::rc::Rc;
 use std::fmt;
+use std::rc::Rc;
 use stdweb::web::html_element::SelectElement;
 use stdweb::web::{Element, EventListenerHandle, FileList, INode, Node};
 use stdweb::{_js_impl, js};
@@ -97,7 +97,7 @@ enum ComponentState<COMP: Component> {
 }
 
 impl<COMP: Component> fmt::Display for ComponentState<COMP> {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = match self {
             ComponentState::Empty => "empty",
             ComponentState::Ready(_) => "ready",
@@ -194,6 +194,7 @@ where
         scheduler().put_and_try_run(Box::new(destroy));
     }
 
+    /// Send a message to the component
     pub fn send_message(&mut self, msg: COMP::Message) {
         self.update(ComponentUpdate::Message(msg));
     }
@@ -283,7 +284,7 @@ where
                     ancestor.detach(this.element.as_node());
                 }
             }
-            ComponentState::Empty | ComponentState::Destroyed => {},
+            ComponentState::Empty | ComponentState::Destroyed => {}
             s @ ComponentState::Processing => panic!("unexpected component state: {}", s),
         };
     }

--- a/src/html.rs
+++ b/src/html.rs
@@ -9,6 +9,7 @@ use crate::virtual_dom::{Listener, VDiff, VNode};
 use log::debug;
 use std::cell::RefCell;
 use std::rc::Rc;
+use std::fmt;
 use stdweb::web::html_element::SelectElement;
 use stdweb::web::{Element, EventListenerHandle, FileList, INode, Node};
 use stdweb::{_js_impl, js};
@@ -46,14 +47,10 @@ pub trait Renderable<COMP: Component> {
 
 /// Updates for a `Components` instance. Used by scope sender.
 pub(crate) enum ComponentUpdate<COMP: Component> {
-    /// Creating an instance of the component
-    Create(ComponentLink<COMP>),
     /// Wraps messages for a component.
     Message(COMP::Message),
     /// Wraps properties for a component.
     Properties(COMP::Properties),
-    /// Removes the component
-    Destroy,
 }
 
 /// Link to component's scope for creating callbacks.
@@ -91,16 +88,84 @@ where
     }
 }
 
+enum ComponentState<COMP: Component> {
+    Empty,
+    Ready(ReadyState<COMP>),
+    Created(CreatedState<COMP>),
+    Processing,
+    Destroyed,
+}
+
+impl<COMP: Component> fmt::Display for ComponentState<COMP> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let name = match self {
+            ComponentState::Empty => "empty",
+            ComponentState::Ready(_) => "ready",
+            ComponentState::Created(_) => "created",
+            ComponentState::Processing => "processing",
+            ComponentState::Destroyed => "destroyed",
+        };
+        write!(f, "{}", name)
+    }
+}
+
+struct ReadyState<COMP: Component> {
+    env: Scope<COMP>,
+    element: Element,
+    occupied: Option<NodeCell>,
+    props: COMP::Properties,
+    link: ComponentLink<COMP>,
+    ancestor: Option<VNode<COMP>>,
+}
+
+impl<COMP: Component> ReadyState<COMP> {
+    fn create(self) -> CreatedState<COMP> {
+        CreatedState {
+            component: COMP::create(self.props, self.link),
+            env: self.env,
+            element: self.element,
+            last_frame: self.ancestor,
+            occupied: self.occupied,
+        }
+    }
+}
+
+struct CreatedState<COMP: Component> {
+    env: Scope<COMP>,
+    element: Element,
+    component: COMP,
+    last_frame: Option<VNode<COMP>>,
+    occupied: Option<NodeCell>,
+}
+
+impl<COMP: Component + Renderable<COMP>> CreatedState<COMP> {
+    fn update(mut self) -> Self {
+        let mut next_frame = self.component.view();
+        let node = next_frame.apply(self.element.as_node(), None, self.last_frame, &self.env);
+        if let Some(ref mut cell) = self.occupied {
+            *cell.borrow_mut() = node;
+        }
+
+        Self {
+            env: self.env,
+            component: self.component,
+            last_frame: Some(next_frame),
+            element: self.element,
+            occupied: self.occupied,
+        }
+    }
+}
+
 /// A context which contains a bridge to send a messages to a loop.
 /// Mostly services uses it.
 pub struct Scope<COMP: Component> {
-    shared_component: Shared<Option<ComponentRunnable<COMP>>>,
+    shared_state: Shared<ComponentState<COMP>>,
 }
 
 impl<COMP: Component> Clone for Scope<COMP> {
     fn clone(&self) -> Self {
         Scope {
-            shared_component: self.shared_component.clone(),
+            shared_state: self.shared_state.clone(),
         }
     }
 }
@@ -109,20 +174,28 @@ impl<COMP> Scope<COMP>
 where
     COMP: Component + Renderable<COMP>,
 {
-    /// Send the message and schedule an update.
-    pub(crate) fn send(&mut self, update: ComponentUpdate<COMP>) {
-        let envelope = ComponentEnvelope {
-            shared_component: self.shared_component.clone(),
-            update,
-        };
-        let runnable: Box<dyn Runnable> = Box::new(envelope);
-        scheduler().put_and_try_run(runnable);
+    pub(crate) fn create(&mut self) {
+        let shared_state = self.shared_state.clone();
+        let create = CreateComponent { shared_state };
+        scheduler().put_and_try_run(Box::new(create));
     }
 
-    /// Send message to a component.
-    pub fn send_message(&mut self, message: COMP::Message) {
-        let update = ComponentUpdate::Message(message);
-        self.send(update);
+    pub(crate) fn update(&mut self, update: ComponentUpdate<COMP>) {
+        let update = UpdateComponent {
+            shared_state: self.shared_state.clone(),
+            update,
+        };
+        scheduler().put_and_try_run(Box::new(update));
+    }
+
+    pub(crate) fn destroy(&mut self) {
+        let shared_state = self.shared_state.clone();
+        let destroy = DestroyComponent { shared_state };
+        scheduler().put_and_try_run(Box::new(destroy));
+    }
+
+    pub fn send_message(&mut self, msg: COMP::Message) {
+        self.update(ComponentUpdate::Message(msg));
     }
 }
 
@@ -134,8 +207,8 @@ where
     COMP: Component + Renderable<COMP>,
 {
     pub(crate) fn new() -> Self {
-        let shared_component = Rc::new(RefCell::new(None));
-        Scope { shared_component }
+        let shared_state = Rc::new(RefCell::new(ComponentState::Empty));
+        Scope { shared_state }
     }
 
     // TODO Consider to use &Node instead of Element as parent
@@ -145,114 +218,105 @@ where
         element: Element,
         ancestor: Option<VNode<COMP>>,
         occupied: Option<NodeCell>,
-        init_props: Option<COMP::Properties>,
+        props: COMP::Properties,
     ) -> Scope<COMP> {
-        let runnable = ComponentRunnable {
-            env: self.clone(),
-            component: None,
-            last_frame: None,
-            element,
-            ancestor,
-            occupied,
-            init_props,
-            destroyed: false,
-        };
         let mut scope = self.clone();
-        *scope.shared_component.borrow_mut() = Some(runnable);
         let link = ComponentLink::connect(&scope);
-        scope.send(ComponentUpdate::Create(link));
+        let ready_state = ReadyState {
+            env: self.clone(),
+            element,
+            occupied,
+            link,
+            props,
+            ancestor,
+        };
+        *scope.shared_state.borrow_mut() = ComponentState::Ready(ready_state);
+        scope.create();
         scope
     }
 }
 
-struct ComponentRunnable<COMP: Component> {
-    env: Scope<COMP>,
-    component: Option<COMP>,
-    last_frame: Option<VNode<COMP>>,
-    element: Element,
-    ancestor: Option<VNode<COMP>>,
-    occupied: Option<NodeCell>,
-    init_props: Option<COMP::Properties>,
-    destroyed: bool,
-}
-
-/// Wraps a component reference and an update to hide it under `Runnable` trait.
-/// It's necessary to schedule a processing of an update.
-struct ComponentEnvelope<COMP>
+struct CreateComponent<COMP>
 where
     COMP: Component,
 {
-    shared_component: Shared<Option<ComponentRunnable<COMP>>>,
-    update: ComponentUpdate<COMP>,
+    shared_state: Shared<ComponentState<COMP>>,
 }
 
-impl<COMP> Runnable for ComponentEnvelope<COMP>
+impl<COMP> Runnable for CreateComponent<COMP>
 where
     COMP: Component + Renderable<COMP>,
 {
     fn run(self: Box<Self>) {
-        let mut component = self.shared_component.borrow_mut();
-        let this = component.as_mut().expect("shared component not set");
-        if this.destroyed {
-            return;
-        }
-        let mut should_update = false;
-        // This loop pops one item, because the following
-        // updates could try to borrow the same cell
-        // Important! Don't use `while let` here, because it
-        // won't free the lock.
-        let env = this.env.clone();
-        match self.update {
-            ComponentUpdate::Create(link) => {
-                let props = this.init_props.take().unwrap_or_default();
-                this.component = Some(COMP::create(props, link));
-                // No messages at start
-                let current_frame = this.component.as_ref().unwrap().view();
-                this.last_frame = Some(current_frame);
-                // First-time rendering the tree
-                let node = this.last_frame.as_mut().unwrap().apply(
-                    this.element.as_node(),
-                    None,
-                    this.ancestor.take(),
-                    &env,
-                );
-                if let Some(ref mut cell) = this.occupied {
-                    *cell.borrow_mut() = node;
+        let current_state = self.shared_state.replace(ComponentState::Processing);
+        self.shared_state.replace(match current_state {
+            ComponentState::Ready(state) => ComponentState::Created(state.create().update()),
+            ComponentState::Created(_) | ComponentState::Destroyed => current_state,
+            ComponentState::Empty | ComponentState::Processing => {
+                panic!("unexpected component state: {}", current_state);
+            }
+        });
+    }
+}
+
+struct DestroyComponent<COMP>
+where
+    COMP: Component,
+{
+    shared_state: Shared<ComponentState<COMP>>,
+}
+
+impl<COMP> Runnable for DestroyComponent<COMP>
+where
+    COMP: Component + Renderable<COMP>,
+{
+    fn run(self: Box<Self>) {
+        match self.shared_state.replace(ComponentState::Destroyed) {
+            ComponentState::Created(mut this) => {
+                this.component.destroy();
+                if let Some(last_frame) = &mut this.last_frame {
+                    last_frame.detach(this.element.as_node());
                 }
             }
-            ComponentUpdate::Message(msg) => {
-                should_update |= this
-                    .component
-                    .as_mut()
-                    .expect("component was not created to process messages")
-                    .update(msg);
+            ComponentState::Ready(mut this) => {
+                if let Some(ancestor) = &mut this.ancestor {
+                    ancestor.detach(this.element.as_node());
+                }
             }
-            ComponentUpdate::Properties(props) => {
-                should_update |= this
-                    .component
-                    .as_mut()
-                    .expect("component was not created to process properties")
-                    .change(props);
+            ComponentState::Empty | ComponentState::Destroyed => {},
+            s @ ComponentState::Processing => panic!("unexpected component state: {}", s),
+        };
+    }
+}
+
+struct UpdateComponent<COMP>
+where
+    COMP: Component,
+{
+    shared_state: Shared<ComponentState<COMP>>,
+    update: ComponentUpdate<COMP>,
+}
+
+impl<COMP> Runnable for UpdateComponent<COMP>
+where
+    COMP: Component + Renderable<COMP>,
+{
+    fn run(self: Box<Self>) {
+        let current_state = self.shared_state.replace(ComponentState::Processing);
+        self.shared_state.replace(match current_state {
+            ComponentState::Created(mut this) => {
+                let should_update = match self.update {
+                    ComponentUpdate::Message(msg) => this.component.update(msg),
+                    ComponentUpdate::Properties(props) => this.component.change(props),
+                };
+                let next_state = if should_update { this.update() } else { this };
+                ComponentState::Created(next_state)
             }
-            ComponentUpdate::Destroy => {
-                // TODO this.component.take() instead of destroyed
-                this.component.as_mut().unwrap().destroy();
-                this.last_frame
-                    .as_mut()
-                    .unwrap()
-                    .detach(this.element.as_node());
-                this.destroyed = true;
+            ComponentState::Destroyed => current_state,
+            ComponentState::Processing | ComponentState::Ready(_) | ComponentState::Empty => {
+                panic!("unexpected component state: {}", current_state);
             }
-        }
-        if should_update {
-            let mut next_frame = this.component.as_ref().unwrap().view();
-            // Re-rendering the tree
-            let node = next_frame.apply(this.element.as_node(), None, this.last_frame.take(), &env);
-            if let Some(ref mut cell) = this.occupied {
-                *cell.borrow_mut() = node;
-            }
-            this.last_frame = Some(next_frame);
-        }
+        });
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@ pub fn run_loop() {
 /// Starts an app mounted to a body of the document.
 pub fn start_app<COMP>()
 where
-    COMP: Component + Renderable<COMP>,
+    COMP: Component<Properties = ()> + Renderable<COMP>,
 {
     initialize();
     App::<COMP>::new().mount_to_body();

--- a/src/scheduler.rs
+++ b/src/scheduler.rs
@@ -19,7 +19,7 @@ pub(crate) fn scheduler() -> Rc<Scheduler> {
 /// A routine which could be run.
 pub(crate) trait Runnable {
     /// Runs a routine with a context instance.
-    fn run(&mut self);
+    fn run(self: Box<Self>);
 }
 
 /// This is a global scheduler suitable to schedule and run any tasks.
@@ -52,7 +52,7 @@ impl Scheduler {
         if self.lock.compare_and_swap(false, true, Ordering::Relaxed) == false {
             loop {
                 let do_next = self.sequence.borrow_mut().pop_front();
-                if let Some(mut runnable) = do_next {
+                if let Some(runnable) = do_next {
                     runnable.run();
                 } else {
                     break;

--- a/src/virtual_dom/vcomp.rs
+++ b/src/virtual_dom/vcomp.rs
@@ -67,12 +67,12 @@ impl<COMP: Component> VComp<COMP> {
                         element,
                         Some(VNode::VRef(ancestor)),
                         Some(occupied.clone()),
-                        Some(props),
+                        props,
                     );
 
                     let destroyer = Box::new({
                         let mut scope = scope.clone();
-                        move || scope.send(ComponentUpdate::Destroy)
+                        move || scope.destroy()
                     });
 
                     Mounted {
@@ -91,11 +91,11 @@ impl<COMP: Component> VComp<COMP> {
                         *Box::from_raw(raw)
                     };
 
-                    scope.send(ComponentUpdate::Properties(props));
+                    scope.update(ComponentUpdate::Properties(props));
 
                     let destroyer = Box::new({
                         let mut scope = scope.clone();
-                        move || scope.send(ComponentUpdate::Destroy)
+                        move || scope.destroy()
                     });
 
                     Mounted {
@@ -159,7 +159,7 @@ where
         let callback = move |arg| {
             let msg = from(arg);
             if let Some(ref mut sender) = *scope.borrow_mut() {
-                sender.send(ComponentUpdate::Message(msg));
+                sender.send_message(msg);
             } else {
                 panic!("unactivated callback, parent component have to activate it");
             }


### PR DESCRIPTION
* Properties no longer need to be wrapped in an `Option`, they will always be set and will be moved to the component instance when it is created
* Remove the `unwrap_or_default` call for `init_props` so that `Properties` does not need to implement `Default` in the future
