### PR TITLE
Increase cache timeout in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 
 cache:
   cargo: true
+  timeout: 1000
   directories:
     - /home/travis/.local/share/cargo-web/emscripten
 


### PR DESCRIPTION
Jobs have been failing recently due to cache timeouts, it should be longer to avoid this issue. Here's an example failure: https://travis-ci.org/DenisKolodin/yew/jobs/555037706

Travis CI docs: https://docs.travis-ci.com/user/caching/#setting-the-timeout