### PR TITLE
html!: fix mixed self-closing and non-sc tags

### DIFF
--- a/tests/macro/html-tag-fail.rs
+++ b/tests/macro/html-tag-fail.rs
@@ -30,6 +30,10 @@ fn compile_fail() {
     html! { <input onclick=|| () /> };
     html! { <input onclick=|a, b| () /> };
     html! { <input onclick=|a: String| () /> };
+
+    // This is a known limitation. Put braces or parenthesis around expressions
+    // that contain '>'.
+    html! { <div> <div onblur=|_| 2 > 1 /> </div> };
 }
 
 fn main() {}

--- a/tests/macro/html-tag-fail.stderr
+++ b/tests/macro/html-tag-fail.stderr
@@ -118,6 +118,13 @@ error: invalid closure argument
 32 |     html! { <input onclick=|a: String| () /> };
    |                            ^^^^^^^^^^^
 
+HELP: You must wrap expressions containing '>' in braces or parenthesis. See #523.
+error: expected valid html element
+  --> $DIR/html-tag-fail.rs:36:39
+   |
+36 |     html! { <div> <div onblur=|_| 2 > 1 /> </div> };
+   |                                       ^
+
 error[E0308]: mismatched types
   --> $DIR/html-tag-fail.rs:22:28
    |

--- a/tests/vtag_test.rs
+++ b/tests/vtag_test.rs
@@ -28,6 +28,48 @@ impl Renderable<Comp> for Comp {
     }
 }
 
+struct CompInt;
+
+impl Component for CompInt {
+    type Message = u32;
+    type Properties = ();
+
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+        CompInt
+    }
+
+    fn update(&mut self, _: Self::Message) -> ShouldRender {
+        unimplemented!();
+    }
+}
+
+impl Renderable<CompInt> for CompInt {
+    fn view(&self) -> Html<Self> {
+        unimplemented!();
+    }
+}
+
+struct CompBool;
+
+impl Component for CompBool {
+    type Message = bool;
+    type Properties = ();
+
+    fn create(_: Self::Properties, _: ComponentLink<Self>) -> Self {
+        CompBool
+    }
+
+    fn update(&mut self, _: Self::Message) -> ShouldRender {
+        unimplemented!();
+    }
+}
+
+impl Renderable<CompBool> for CompBool {
+    fn view(&self) -> Html<Self> {
+        unimplemented!();
+    }
+}
+
 #[test]
 fn it_compares_tags() {
     let a: VNode<Comp> = html! {
@@ -257,4 +299,37 @@ fn it_allows_aria_attributes() {
     } else {
         panic!("vtag expected");
     }
+}
+
+#[test]
+fn it_checks_mixed_closing_tags() {
+    let a: VNode<Comp> = html! { <div> <div/>      </div> };
+    let b: VNode<Comp> = html! { <div> <div></div> </div> };
+    assert_eq!(a, b);
+
+    let a: VNode<Comp> = html! { <div> <div data-val={ 2 / 1 }/>  </div> };
+    let b: VNode<Comp> = html! { <div> <div data-val={ 2 }></div> </div> };
+    assert_eq!(a, b);
+
+    let a: VNode<Comp> = html! { <div> <div data-val={ 2 > 1 }/>  </div> };
+    let b: VNode<Comp> = html! { <div> <div data-val={ true }></div> </div> };
+    assert_eq!(a, b);
+
+    let a: VNode<CompInt> = html! { <div> <div onblur=|_| 2 / 1/>  </div> };
+    let b: VNode<CompInt> = html! { <div> <div onblur=|_| 3></div> </div> };
+    assert_eq!(a, b); // NB: assert_eq! doesn't (cannot) compare the closures
+
+    // This is a known limitation of the html! macro:
+    //
+    //   html! { <div> <img onblur=|_| 2 > 1 /> </div> }
+    //
+    // You have to put braces or parenthesis around the expression:
+    //
+    //   html! { <div> <img onblur=|_| { 2 > 1 } /> </div> }
+    //
+    let a: VNode<CompBool> = html! { <div> <div onblur=|_| { 2 > 1 } />  </div> };
+    let b: VNode<CompBool> = html! { <div> <div onblur=|_| ( 2 > 1 ) />  </div> };
+    let c: VNode<CompBool> = html! { <div> <div onblur=|_| false></div> </div> };
+    assert_eq!(a, c); // NB: assert_eq! doesn't (cannot) compare the closures
+    assert_eq!(b, c);
 }


### PR DESCRIPTION
Before, self-closing tags where considered as open tags in `verify_end`, causing codes like this to not compile:

```rust
html! {
    <div>
        <div/> // <- considered as open tag
    </div>
}
```

```
error: this open tag has no corresponding close tag
   --> src/lib.rs:264:17
    |
... | <div>
    | ^^^^^
```

However, this fix isn't ideal because it peeks the buffer twice for non self-closing tags. I did it that way in order to keep the peek thing. An alternative would be to turn `HtmlSelfClosingTag::peek` into a standard function returning `(ident, is_self_closing)`.

Fixes: #522