### PR TITLE
Fix CI wasm tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ matrix:
 install:
   - nvm install 9
   - rustup target add wasm32-unknown-unknown
-  - cargo install wasm-bindgen-cli --force
+  - cargo install --force --version 0.2.42 -- wasm-bindgen-cli
   - curl --retry 5 -LO https://chromedriver.storage.googleapis.com/2.41/chromedriver_linux64.zip
   - unzip chromedriver_linux64.zip
   - ./ci/install_cargo_web.sh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ toml = { version = "0.4", optional = true }
 yew-macro = { version = "0.8.0", path = "crates/macro" }
 
 [target.'cfg(all(target_arch = "wasm32", not(cargo_web)))'.dependencies]
-wasm-bindgen = "0.2"
+wasm-bindgen = "=0.2.42"
 
 [dev-dependencies]
 serde_derive = "1"
@@ -50,6 +50,7 @@ wasm-bindgen-test = "0.2"
 [features]
 default = []
 web_test = []
+wasm_test = []
 yaml = ["serde_yaml"]
 msgpack = ["rmp-serde"]
 cbor = ["serde_cbor"]

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -24,7 +24,7 @@ echo "Testing for wasm32-unknown-emscripten..."
 cargo web test --features web_test --target=wasm32-unknown-emscripten
 
 echo "Testing for wasm32-unknown-unknown..."
-cargo test --target=wasm32-unknown-unknown
+cargo test --features wasm_test --target=wasm32-unknown-unknown
 
 echo "Testing html macro..."
 cargo test --test macro_test

--- a/examples/js_callback/Cargo.toml
+++ b/examples/js_callback/Cargo.toml
@@ -9,4 +9,4 @@ yew = { path = "../.." }
 stdweb = "^0.4.16"
 
 [target.'cfg(all(target_arch = "wasm32", not(cargo_web)))'.dependencies]
-wasm-bindgen = "0.2"
+wasm-bindgen = "=0.2.42"

--- a/tests/format_test.rs
+++ b/tests/format_test.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-#[cfg(feature = "wasm-bindgen-test")]
+#[cfg(feature = "wasm_test")]
 use wasm_bindgen_test::wasm_bindgen_test as test;
 use yew::format::{Binary, Json, Text};
 

--- a/tests/vcomp_test.rs
+++ b/tests/vcomp_test.rs
@@ -1,10 +1,10 @@
-#[cfg(feature = "wasm-bindgen-test")]
+#[cfg(feature = "wasm_test")]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::macros::Properties;
 use yew::virtual_dom::VNode;
 use yew::{html, Component, ComponentLink, Html, Renderable, ShouldRender};
 
-#[cfg(feature = "wasm-bindgen-test")]
+#[cfg(feature = "wasm_test")]
 wasm_bindgen_test_configure!(run_in_browser);
 
 struct Comp;

--- a/tests/vlist_test.rs
+++ b/tests/vlist_test.rs
@@ -1,9 +1,9 @@
-#[cfg(feature = "wasm-bindgen-test")]
+#[cfg(feature = "wasm_test")]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::virtual_dom::VNode;
 use yew::{html, Component, ComponentLink, Html, Renderable, ShouldRender};
 
-#[cfg(feature = "wasm-bindgen-test")]
+#[cfg(feature = "wasm_test")]
 wasm_bindgen_test_configure!(run_in_browser);
 
 struct Comp;

--- a/tests/vtag_test.rs
+++ b/tests/vtag_test.rs
@@ -1,10 +1,10 @@
 #![recursion_limit = "128"]
-#[cfg(feature = "wasm-bindgen-test")]
+#[cfg(feature = "wasm_test")]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::virtual_dom::VNode;
 use yew::{html, Component, ComponentLink, Html, Renderable, ShouldRender};
 
-#[cfg(feature = "wasm-bindgen-test")]
+#[cfg(feature = "wasm_test")]
 wasm_bindgen_test_configure!(run_in_browser);
 
 struct Comp;

--- a/tests/vtext_test.rs
+++ b/tests/vtext_test.rs
@@ -1,9 +1,9 @@
-#[cfg(feature = "wasm-bindgen-test")]
+#[cfg(feature = "wasm_test")]
 use wasm_bindgen_test::{wasm_bindgen_test as test, wasm_bindgen_test_configure};
 use yew::virtual_dom::VNode;
 use yew::{html, Component, ComponentLink, Html, Renderable, ShouldRender};
 
-#[cfg(feature = "wasm-bindgen-test")]
+#[cfg(feature = "wasm_test")]
 wasm_bindgen_test_configure!(run_in_browser);
 
 struct Comp;


### PR DESCRIPTION
- wasm tests have not been running on Ci
- fix wasm-bindgen to version 0.2.42 for now since later versions break stdweb